### PR TITLE
Medium of Exchange Categories - wording change (#81)

### DIFF
--- a/ui/src/lib/components/moe/MoEInitializer.svelte
+++ b/ui/src/lib/components/moe/MoEInitializer.svelte
@@ -30,9 +30,9 @@
   // Predefined Medium of Exchange options based on user requirements
   const predefinedMediums: MediumOfExchangeInDHT[] = [
     // Base exchange categories (foundational types)
-    { code: 'PAY_IT_FORWARD', name: 'Pay it Forward/Free', exchange_type: 'base' },
+    { code: 'PAY_IT_FORWARD', name: 'Free/Pay it Forward', exchange_type: 'base' },
     { code: 'EXCHANGE_SERVICES', name: 'Service Exchange', exchange_type: 'base' },
-    { code: 'OPEN_DISCUSSION', name: 'Flexible Exchange', exchange_type: 'base' }
+    { code: 'OPEN_DISCUSSION', name: 'Let's Discuss', exchange_type: 'base' }
   ];
 
   // Check if there are existing mediums of exchange
@@ -211,8 +211,8 @@
           </div>
           <ul class="ml-2 list-inside list-disc space-y-1 text-xs">
             <li>Service Exchange</li>
-            <li>Pay it Forward/Free</li>
-            <li>Flexible Exchange</li>
+            <li>Free/Pay it Forward</li>
+            <li>Let's Discuss</li>
           </ul>
           <p class="text-xs italic text-surface-500">
             Foundational exchange frameworks for non-monetary trades

--- a/ui/tests/e2e/fixtures/realistic-data-generator.ts
+++ b/ui/tests/e2e/fixtures/realistic-data-generator.ts
@@ -123,13 +123,8 @@ export class RealisticDataGenerator {
 
   private static readonly MEDIUMS_OF_EXCHANGE = [
     { code: 'USD', name: 'US Dollar' },
-    { code: 'EUR', name: 'Euro' },
-    { code: 'CAD', name: 'Canadian Dollar' },
-    { code: 'GBP', name: 'British Pound' },
-    { code: 'PAY_IT_FORWARD', name: 'Pay it Forward' },
+    { code: 'PAY_IT_FORWARD', name: 'Free/Pay it Forward' },
     { code: 'SKILL_EXCHANGE', name: 'Skill Exchange' },
-    { code: 'TIME_BANKING', name: 'Time Banking' },
-    { code: 'BARTER', name: 'Barter System' }
   ];
 
   private static readonly TIME_ZONES = [


### PR DESCRIPTION
Updates MoE labels per @MsAnita's request:

"Pay it Forward/Free" → "Free/Pay it Forward"
"Flexible Exchange" → "Let's Discuss"
Also removes unused test MoE entries: EUR, CAD, GBP, TIME_BANKING, BARTER

Closes #81