### PR TITLE
fix(requests): repair active link management in update_request and update_offer

### DIFF
--- a/dnas/requests_and_offers/zomes/coordinator/offers/src/offer.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/offers/src/offer.rs
@@ -382,39 +382,42 @@ pub fn update_offer(input: UpdateOfferInput) -> ExternResult<Record> {
     return Err(CommonError::CannotUpdateArchived("offer".to_string()).into());
   }
 
+  let previous_hash = input.previous_action_hash.0.clone();
   let updated_offer_hash = update_entry(input.previous_action_hash.into(), &input.updated_offer)?;
 
-  // Update the link from "offers" path to point to the new record
-  // This ensures get_all_offers returns the latest version
-  let path = Path::from("offers");
-  let path_hash = path.path_entry_hash()?;
-  let link_type_filter = LinkTypes::AllOffers
+  // Update the ActiveOffers link in "offers.active" to point to the new record.
+  // create_offer uses Path::from("offers.active") + LinkTypes::ActiveOffers, so
+  // we must use the same path and link type here, or get_active_offers will keep
+  // returning the original (pre-edit) record.
+  let active_path = Path::from("offers.active");
+  let active_path_hash = active_path.path_entry_hash()?;
+  let active_link_filter = LinkTypes::ActiveOffers
     .try_into_filter()
     .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
-  let links = get_links(
-    LinkQuery::new(path_hash.clone(), link_type_filter),
+  let active_links = get_links(
+    LinkQuery::new(active_path_hash.clone(), active_link_filter),
     GetStrategy::Local,
   )?;
 
-  // Find and remove the old link pointing to the original offer
-  for link in links {
+  // Find and remove the link pointing to the current (previous) hash
+  for link in active_links {
     if let Some(hash) = link.target.clone().into_action_hash() {
-      if hash == input.original_action_hash.0 {
+      if hash == previous_hash {
         delete_link(link.create_link_hash, GetOptions::default())?;
         break;
       }
     }
   }
 
-  // Create new link pointing to the updated offer
+  // Create new ActiveOffers link pointing to the updated record
   create_link(
-    path_hash.clone(),
+    active_path_hash.clone(),
     updated_offer_hash.clone(),
-    LinkTypes::AllOffers,
+    LinkTypes::ActiveOffers,
     (),
   )?;
 
-  // Also create the update tracking link
+  // Create the update tracking link (original → updated, for get_latest_offer_record)
   create_link(
     input.original_action_hash,
     updated_offer_hash.clone(),

--- a/dnas/requests_and_offers/zomes/coordinator/requests/src/request.rs
+++ b/dnas/requests_and_offers/zomes/coordinator/requests/src/request.rs
@@ -385,40 +385,43 @@ pub fn update_request(input: UpdateRequestInput) -> ExternResult<Record> {
     return Err(CommonError::CannotUpdateArchived("request".to_string()).into());
   }
 
+  let previous_hash = input.previous_action_hash.0.clone();
   let updated_request_hash =
     update_entry(input.previous_action_hash.into(), &input.updated_request)?;
 
-  // Update the link from "requests" path to point to the new record
-  // This ensures get_all_requests returns the latest version
-  let path = Path::from("requests");
-  let path_hash = path.path_entry_hash()?;
-  let link_type_filter = LinkTypes::AllRequests
+  // Update the ActiveRequests link in "requests.active" to point to the new record.
+  // create_request uses Path::from("requests.active") + LinkTypes::ActiveRequests, so
+  // we must use the same path and link type here, or get_active_requests will keep
+  // returning the original (pre-edit) record.
+  let active_path = Path::from("requests.active");
+  let active_path_hash = active_path.path_entry_hash()?;
+  let active_link_filter = LinkTypes::ActiveRequests
     .try_into_filter()
     .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?;
-  let links = get_links(
-    LinkQuery::new(path_hash.clone(), link_type_filter),
+  let active_links = get_links(
+    LinkQuery::new(active_path_hash.clone(), active_link_filter),
     GetStrategy::Local,
   )?;
 
-  // Find and remove the old link pointing to the original request
-  for link in links {
+  // Find and remove the link pointing to the current (previous) hash
+  for link in active_links {
     if let Some(hash) = link.target.clone().into_action_hash() {
-      if hash == input.original_action_hash.0 {
+      if hash == previous_hash {
         delete_link(link.create_link_hash, GetOptions::default())?;
         break;
       }
     }
   }
 
-  // Create new link pointing to the updated request
+  // Create new ActiveRequests link pointing to the updated record
   create_link(
-    path_hash.clone(),
+    active_path_hash.clone(),
     updated_request_hash.clone(),
-    LinkTypes::AllRequests,
+    LinkTypes::ActiveRequests,
     (),
   )?;
 
-  // Also create the update tracking link
+  // Create the update tracking link (original → updated, for get_latest_request_record)
   create_link(
     input.original_action_hash,
     updated_request_hash.clone(),

--- a/ui/src/lib/stores/offers.store.svelte.ts
+++ b/ui/src/lib/stores/offers.store.svelte.ts
@@ -719,7 +719,16 @@ export const createOffersStore = (): E.Effect<
           E.flatMap((record) => {
             if (!record) return E.succeed(null);
             // Use enhanced creation to fetch related data (service types, medium of exchange, creator)
-            return createEnhancedUIOffer(record, offersService);
+            return pipe(
+              createEnhancedUIOffer(record, offersService),
+              E.map((entity) => {
+                // Preserve the original creation hash — the returned record may be an update
+                // record whose hash differs from the original. Without this, repeated edits
+                // would pass the wrong original_action_hash to updateOffer.
+                entity.original_action_hash = originalActionHash;
+                return entity;
+              })
+            );
           }),
           E.catchAll((error) =>
             E.fail(OfferError.fromError(error, OFFER_CONTEXTS.GET_LATEST_OFFER))

--- a/ui/src/lib/stores/requests.store.svelte.ts
+++ b/ui/src/lib/stores/requests.store.svelte.ts
@@ -750,7 +750,17 @@ export const createRequestsStore = (): E.Effect<
           E.flatMap((record) => {
             if (!record) return E.succeed(null);
             // Use enhanced creation to fetch related data (service types, medium of exchange, creator)
-            return createEnhancedUIRequest(record, requestsService);
+            return pipe(
+              createEnhancedUIRequest(record, requestsService),
+              E.map((entity) => {
+                // The record returned by getLatestRequestRecord may be an update record whose
+                // hash differs from the original creation hash. Preserve the original hash so
+                // the edit page passes the correct original_action_hash to updateRequest, and
+                // so cache lookups by original hash continue to work after repeated edits.
+                entity.original_action_hash = originalActionHash;
+                return entity;
+              })
+            );
           }),
           E.catchAll((error) =>
             E.fail(RequestError.fromError(error, REQUEST_CONTEXTS.GET_LATEST_REQUEST))

--- a/ui/src/routes/(public)/requests/[id]/edit/+page.svelte
+++ b/ui/src/routes/(public)/requests/[id]/edit/+page.svelte
@@ -110,12 +110,8 @@
         )
       );
 
-      toastStore.trigger({
-        message: 'Request updated successfully!',
-        background: 'variant-filled-success'
-      });
-
       // Navigate back to the request detail page
+      // (success toast is already triggered by RequestForm)
       goto(`/requests/${requestId}`);
     } catch (err) {
       console.error('Failed to update request:', err);


### PR DESCRIPTION
## Intent

Editing a Request (or Offer) appeared to succeed — the success toast fired and no error was thrown — but the changes never appeared in the listing or after a page reload. This PR fixes the root cause in the coordinator zomes and two contributing bugs in the frontend stores.

## Changes

**Coordinator zomes (requests + offers) — root cause**

`update_request` and `update_offer` were managing links under `Path::from("requests")` / `LinkTypes::AllRequests` (and the offers equivalent), but `create_request` / `create_offer` create links under `Path::from("requests.active")` / `LinkTypes::ActiveRequests`. The cleanup loop in the update functions never found a matching link (wrong path and type), so it was always a no-op. After any edit, `get_active_requests` kept following the original `ActiveRequests` links, returning the pre-edit record on every listing fetch or page reload.

Fix: replace the wrong path/link-type block with `requests.active` / `ActiveRequests` (and `offers.active` / `ActiveOffers`). Match the deletion against `previous_action_hash` (the current latest hash before this update) so the correct link is found and re-pointed on both first and subsequent edits.

**Store — `original_action_hash` preservation**

`getLatestRequest` and `getLatestOffer` call `createEnhancedUIRequest/Offer` with the record returned by `getLatestRequestRecord`. For an updated record, that record's hash is the latest update hash, not the original creation hash. `createUIEntityFromRecord` sets `original_action_hash` to the record's own hash, so after any previous edit the loaded entity carries the wrong `original_action_hash`. The edit page passes this value to `updateRequest`/`updateOffer` as the `original_action_hash` argument, corrupting the `RequestUpdates` / `OfferUpdates` link chain on second and subsequent edits.

Fix: after `createEnhancedUIRequest/Offer` returns, override `entity.original_action_hash` with the `originalActionHash` parameter (the original creation hash passed into `getLatestRequest/Offer`).

**Edit page — duplicate success toast (cosmetic)**

Both `RequestForm.handleSubmit` and the edit page's `handleSubmit` fired an independent success toast on update, producing the double notification reported in the issue. Removed the redundant toast from the edit page; the form's toast is sufficient.

## Decisions

| Option | Rejected because |
|--------|-----------------|
| Delete old link by `original_action_hash` instead of `previous_action_hash` | Works for first edit only; after a first edit the active link points to the first update hash, not the original creation hash |
| Fix only requests, leave offers | Same structural bug; proactive fix avoids filing a separate issue |

## How to test

1. Create a Request with time preference set to "No Preference"
2. Edit the Request, change time preference to "Morning", save
3. Navigate back to the listing — the updated time preference should appear without a page reload
4. Refresh the page — the updated value should persist
5. Edit again (second edit) — changes should persist the same way
6. Repeat steps 1–5 for an Offer to verify the offers fix

## Related

Closes #87
