### PR TITLE
fix(organizations): resolve original hash from Update action records for member display

### DIFF
--- a/ui/src/lib/stores/organizations.store.svelte.ts
+++ b/ui/src/lib/stores/organizations.store.svelte.ts
@@ -346,11 +346,33 @@ export const createOrganizationsStore = (): E.Effect<
           E.flatMap((record) => {
             if (!record) return E.succeed(null);
 
+            // Resolve the true original creation hash from the record.
+            // When navigating from a list that used an update-action hash in the URL,
+            // the passed hash is the update hash. An Update action exposes
+            // original_action_address pointing back to the CREATE action, which is
+            // where all member/coordinator links are anchored. Using the update hash
+            // for link lookups returns empty results — hence the "No members found" bug.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const actionContent = record.signed_action.hashed.content as any;
+            const trueOriginalHash: ActionHash =
+              actionContent.type === 'Update' && actionContent.original_action_address
+                ? (actionContent.original_action_address as ActionHash)
+                : record.signed_action.hashed.hash;
+
             return pipe(
-              createEnhancedUIOrganization(record, organizationsService, original_action_hash),
+              createEnhancedUIOrganization(record, organizationsService, trueOriginalHash),
+              E.map((organization) => {
+                if (!organization) return null;
+                // Override with correct hashes (mirrors the user store fix from Issue #57)
+                return {
+                  ...organization,
+                  original_action_hash: trueOriginalHash,
+                  previous_action_hash: record.signed_action.hashed.hash
+                } as UIOrganization;
+              }),
               E.tap((organization) => {
                 if (organization) {
-                  E.runSync(cache.set(original_action_hash.toString(), organization));
+                  E.runSync(cache.set(trueOriginalHash.toString(), organization));
                   syncCacheToState(organization, 'add');
                   eventEmitters.emitCreated(organization);
                 }

--- a/ui/tests/unit/stores/organizations.store.test.ts
+++ b/ui/tests/unit/stores/organizations.store.test.ts
@@ -185,6 +185,85 @@ describe('OrganizationsStore', () => {
     });
   });
 
+  describe('getLatestOrganization - Update action hash regression (#113)', () => {
+    it('should use original_action_address when record is an Update action', async () => {
+      // Regression test for: when an org is updated, navigating via the update-hash URL
+      // caused getOrganizationMembersLinks to be called with the update hash instead of the
+      // original creation hash, returning empty members.
+      const originalHash = new Uint8Array(39).fill(1); // simulated creation hash
+      const updateHash = new Uint8Array(39).fill(2); // simulated update hash
+      const memberHash = new Uint8Array(39).fill(3); // simulated member hash
+
+      // Simulate an Update record (has type + original_action_address)
+      const updateRecord = {
+        ...createMockRecord(testOrganizations.main, updateHash),
+        signed_action: {
+          hashed: {
+            hash: updateHash,
+            content: {
+              type: 'Update',
+              original_action_address: originalHash, // points back to creation hash
+              timestamp: Date.now() * 1000
+            }
+          }
+        }
+      };
+
+      vi.mocked(mockOrganizationService.getLatestOrganizationRecord).mockReturnValue(
+        E.succeed(updateRecord as any)
+      );
+
+      // Members are anchored to originalHash — only return them when called with originalHash
+      vi.mocked(mockOrganizationService.getOrganizationMembersLinks).mockImplementation(
+        (hash) =>
+          new Uint8Array(hash).every((b, i) => b === originalHash[i])
+            ? E.succeed([{ target: memberHash }] as any)
+            : E.succeed([])
+      );
+
+      vi.mocked(mockOrganizationService.getOrganizationCoordinatorsLinks).mockReturnValue(
+        E.succeed([])
+      );
+      vi.mocked(mockOrganizationService.getOrganizationContactsLinks).mockReturnValue(
+        E.succeed([])
+      );
+
+      // Call with the UPDATE hash (simulating a URL with the update hash)
+      const result = await E.runPromise(store.getLatestOrganization(updateHash as any));
+
+      expect(result).not.toBeNull();
+      // original_action_hash must be the CREATION hash, not the update hash
+      expect(result!.original_action_hash).toBe(originalHash);
+      // members must be populated (fetched with correct creation hash)
+      expect(result!.members).toHaveLength(1);
+    });
+
+    it('should use record hash for Create actions (no original_action_address)', async () => {
+      const creationHash = testOrganizations.main.original_action_hash!;
+      const mockRecord = createMockRecord(testOrganizations.main, creationHash);
+      // Create action has no type field (or type !== 'Update')
+
+      vi.mocked(mockOrganizationService.getLatestOrganizationRecord).mockReturnValue(
+        E.succeed(mockRecord)
+      );
+      vi.mocked(mockOrganizationService.getOrganizationMembersLinks).mockReturnValue(
+        E.succeed([])
+      );
+      vi.mocked(mockOrganizationService.getOrganizationCoordinatorsLinks).mockReturnValue(
+        E.succeed([])
+      );
+      vi.mocked(mockOrganizationService.getOrganizationContactsLinks).mockReturnValue(
+        E.succeed([])
+      );
+
+      const result = await E.runPromise(store.getLatestOrganization(creationHash));
+
+      expect(result).not.toBeNull();
+      // For Create actions, original_action_hash is the record hash itself
+      expect(result!.original_action_hash).toBe(creationHash);
+    });
+  });
+
   describe('createOrganization', () => {
     it('should create organization with required full_legal_name field', async () => {
       const newOrg: OrganizationInDHT = {


### PR DESCRIPTION
## Intent

Organizations that have been updated (name, description, etc.) show "No members found" and "No coordinators found" on the detail page, even when they have active members and coordinators. The "Add Member" and "Add Coordinator" buttons also fail to appear for the actual coordinator.

The root cause: `createUIEntityFromRecord` sets `original_action_hash` to `record.signed_action.hashed.hash` — the latest update action hash, not the original creation hash. When the org list page sets navigation links using this hash, the detail page calls `getLatestOrganization(updateHash)`. This passes `updateHash` to `createEnhancedUIOrganization`, which calls `getOrganizationMembersLinks(updateHash)` — returning empty because member and coordinator links are anchored to the original creation hash.

## Changes

**Resolves Update action hash mismatch in `getLatestOrganization`:**

- After fetching the latest organization record, check whether the record is an Update action (has `original_action_address`)
- If it is an Update, extract the true original creation hash from `original_action_address`
- Pass the true original hash to `createEnhancedUIOrganization` so member and coordinator link lookups use the correct base hash
- Override `UIOrganization.original_action_hash` with the true original hash and `previous_action_hash` with the latest record hash
- Cache using the true original hash as key

This mirrors the fix applied to users in Issue #57 (`getLatestUser` already uses `originalActionHash` parameter for override).

## Decisions

| Option | Rejected because |
|--------|-----------------|
| Fix `createUIEntityFromRecord` to detect Update actions globally | Would affect all entity types; the per-store override matches the existing user pattern and is more surgical |
| Add a Rust zome function to resolve the original hash | Unnecessary since the record itself carries `original_action_address`; no zome change needed |

## How to test

1. Create an organization
2. Edit it (update description or any field)
3. Navigate to the org list page — links to the org should use the creation hash (previously used the update hash after edit)
4. Open the organization detail page
5. Switch to Members tab — should show members (previously "No members found")
6. Switch to Coordinators tab — should show coordinators (previously "No coordinators found")
7. "Add Member" and "Add Coordinator" buttons should appear if you are a coordinator

**Regression tests:** `ui/tests/unit/stores/organizations.store.test.ts` — two new tests verify the Update action detection and hash resolution.

## Related

Closes #113
- Related #57 (same bug pattern, fixed for users)
- Related #109 (previous partial fix for member/coordinator display)