### PR TITLE
docs(progenitor): document the progenitor pattern

### DIFF
--- a/documentation/DOCUMENTATION_INDEX.md
+++ b/documentation/DOCUMENTATION_INDEX.md
@@ -45,10 +45,14 @@
 
 #### 🏗️ Architecture (`/architecture/`)
 
-- **[Architecture README](architecture/README.md)** - Architecture documentation overview
+- **[Architecture README](architecture/README.md)** - Architecture overview: component layout, 7-layer pattern, network bootstrap
 - **[Architecture Overview](architecture.md)** - System architecture and design patterns
 - **[App Runtime (Effect TS)](architecture/app-runtime.md)** - Centralized runtime and DI with AppServicesTag
 - **[hREA Integration](architecture/hrea-integration.md)** - Holochain REA framework integration
+
+#### 🔑 Key Patterns
+
+- **[The Progenitor Pattern](progenitor.md)** - Network bootstrap: founding agent, auto-registration, dev vs production modes, API, testing ⭐
 
 #### 📋 Requirements (`/requirements/`)
 

--- a/documentation/TROUBLESHOOTING.md
+++ b/documentation/TROUBLESHOOTING.md
@@ -63,6 +63,30 @@ ps aux | grep holochain
 ps aux | grep lair-keystore
 ```
 
+### Administration & Progenitor Issues
+
+#### **Issue**: I created a user but I'm not an administrator
+
+**Cause**: In production mode, only the designated progenitor is auto-registered as admin on `create_user`. If someone joined the network before the progenitor and created a profile, they receive `Pending` status like any other user.
+
+**Diagnose**:
+
+```bash
+# Check whether progenitor_pubkey is configured in your happ.yaml
+grep "progenitor_pubkey" workdir/happ.yaml
+# null (~) means dev mode — first user becomes admin
+# a base64 key means production mode — only that key becomes admin
+```
+
+In the UI you can call `is_progenitor()` from the `administration` zome to check if your current agent is the progenitor. If it returns `false` and no admin exists yet, the progenitor has not yet called `create_user`.
+
+**Solutions**:
+
+- **Dev mode** (`progenitor_pubkey: ~`): ensure your agent is the first one to call `create_user` after a clean sandbox reset (`bun start` wipes the sandbox each run).
+- **Production mode**: verify the correct agent pubkey is set as `progenitor_pubkey`. Use Kangaroo to install the hApp — it sets the key automatically. If deploying manually, read the agent key from the conductor admin API and set it in `workdir/happ.yaml` before `bun build:happ`.
+
+For a full explanation of the two modes see [The Progenitor Pattern](progenitor.md).
+
 ### Build Issues
 
 #### **Issue**: Zome compilation failures

--- a/documentation/architecture/README.md
+++ b/documentation/architecture/README.md
@@ -1,0 +1,63 @@
+# Architecture Overview
+
+This document provides a high-level overview of the system architecture — component layout, key design decisions, and where to find deeper documentation for each area.
+
+## System Components
+
+```
+requests-and-offers/
+├── dnas/requests_and_offers/     # Holochain DNA (Rust)
+│   ├── zomes/coordinator/        # Business logic (extern functions)
+│   ├── zomes/integrity/          # Entry & link types, validation rules
+│   └── utils/                    # Shared utilities (progenitor check, DNA props)
+├── ui/                           # SvelteKit 5 frontend
+│   └── src/lib/
+│       ├── services/             # Effect-TS services — one per domain
+│       ├── stores/               # Svelte 5 Rune-based stores
+│       ├── composables/          # Business logic bridging stores and components
+│       ├── schemas/              # Effect Schema validation
+│       └── errors/               # Tagged error definitions
+└── tests/sweettest/              # Rust integration tests (Holochain Sweettest)
+```
+
+## 7-Layer Frontend Architecture
+
+The frontend follows a strict layered pattern. Each domain (Service Types, Requests, Offers, Users, Organizations, Administration, Exchanges, Mediums of Exchange) implements all seven layers:
+
+1. **Service** — Effect-native service with `Context.Tag` dependency injection
+2. **Store** — Svelte 5 Runes with Effect integration
+3. **Schema** — `Schema.Class` validation at business boundaries
+4. **Errors** — `Data.TaggedError` domain-specific errors
+5. **Composables** — component logic abstraction
+6. **Components** — Svelte 5 with accessibility focus
+7. **Testing** — Vitest unit tests per layer
+
+For detailed patterns see [Architectural Patterns](../guides/architectural-patterns.md) and [Effect-TS Primer](../guides/effect-ts-primer.md).
+
+## Network Bootstrap: The Progenitor Pattern
+
+Holochain has no central authority to assign the first administrator. The **progenitor pattern** solves this by embedding the founding agent's public key directly in the DNA properties at network creation time.
+
+When the progenitor calls `create_user`, the `users_organizations` coordinator detects the match and automatically registers them as the first administrator via a cross-zome call to `administration::add_administrator`. No explicit admin registration step is required.
+
+**Two deployment modes:**
+
+| Mode | `progenitor_pubkey` in `workdir/happ.yaml` | First admin |
+|------|---------------------------------------------|-------------|
+| Production | Set to the creator's actual agent pubkey | Only the progenitor |
+| Dev / local | `~` (null) | First agent to call `create_user` |
+
+The progenitor is a regular, revocable administrator — no permanent elevated privilege. The integrity zome delegates all authorization to the coordinator layer (HDI 0.7.0 does not support `get_links` inside validation callbacks).
+
+For a full explanation including configuration, API reference, and test patterns, see [The Progenitor Pattern](../progenitor.md).
+
+## hREA Integration
+
+The project integrates the hREA (Holochain Resource-Event-Agent) framework for Valueflows-based economic coordination. For details see [hREA Integration](hrea-integration.md).
+
+## Further Reading
+
+- [Architectural Patterns Guide](../guides/architectural-patterns.md) — 7-layer deep-dive
+- [The Progenitor Pattern](../progenitor.md) — network bootstrap mechanism
+- [Administration Zome Spec](../technical-specs/zomes/administration.md) — admin/progenitor API
+- [hREA Integration](hrea-integration.md) — Valueflows economic layer

--- a/documentation/guides/installation.md
+++ b/documentation/guides/installation.md
@@ -521,11 +521,40 @@ bun start
 
 **Warning**: This will remove all local data and require rebuilding everything.
 
+### Production Network Setup
+
+By default, `workdir/happ.yaml` ships with `progenitor_pubkey: ~` (null), which means the first agent to create a profile becomes the network administrator — convenient for development but unsuitable for production.
+
+For a production deployment you must set the progenitor's agent public key before building the hApp:
+
+**Using Kangaroo (recommended)**: The Kangaroo Electron app handles this automatically. It reads the creator's agent public key from the Holochain conductor admin WebSocket and injects it into DNA properties before installing the hApp. No manual configuration is needed.
+
+**Manual configuration**:
+
+1. Obtain the agent public key from the Holochain conductor admin API (base64-encoded `AgentPubKey`).
+
+2. Set it in `workdir/happ.yaml`:
+
+```yaml
+properties:
+  progenitor_pubkey: uhCAkXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+3. Rebuild the hApp:
+
+```bash
+bun build:happ
+```
+
+The agent whose key is set will be automatically registered as the first network administrator when they call `create_user`. All other agents receive standard `Pending` status regardless of join order.
+
+For a full explanation of the progenitor pattern see [The Progenitor Pattern](../progenitor.md).
+
 ### Documentation
 
 - [Getting Started](./getting-started.md)
 - [Contributing Guide](./contributing.md)
-- [Technical Documentation](../architecture/overview.md) & [Technical Specifications](../technical-specs/general.md)
+- [Technical Documentation](../architecture/README.md) & [Technical Specifications](../technical-specs/general.md)
 - [API Documentation](../technical-specs/zomes/)
-- [System Architecture](../architecture/overview.md)
+- [System Architecture](../architecture/README.md)
 - [Feature Specifications](../requirements/features.md)

--- a/documentation/guides/testing.md
+++ b/documentation/guides/testing.md
@@ -272,6 +272,15 @@ mod tests {
 
 ### Sweettest Multi-Agent Tests
 
+#### Choosing the right setup helper
+
+Two multi-agent setup functions exist in `tests/sweettest/src/common/conductors.rs`:
+
+- **`setup_two_agents_with_alice_as_progenitor()`** — Alice's key is pre-generated and embedded in DNA properties before app installation. Alice becomes admin automatically when she calls `create_user`. Use this for any test that requires Alice to be an administrator or that tests progenitor-gated behavior.
+- **`setup_two_agents()`** — uses a hardcoded key (`HARDCODED_PROGENITOR_PUBKEY`) that neither Alice nor Bob matches. Neither agent is auto-registered as admin. Use this when admin status is irrelevant to the test.
+
+See [The Progenitor Pattern](../progenitor.md#writing-tests) for the full test-writing guide.
+
 ```rust
 // tests/sweettest/tests/service_types.rs
 use holochain::prelude::*;

--- a/documentation/progenitor.md
+++ b/documentation/progenitor.md
@@ -1,0 +1,191 @@
+# The Progenitor Pattern
+
+The progenitor pattern is the network bootstrap mechanism for this hApp. It designates a trusted founding agent whose identity is embedded in the DNA itself, ensuring that the very first administrator is known before anyone joins the network.
+
+## Why It Exists
+
+Holochain networks have no central server to assign roles. Anyone who installs the same DNA hash joins the same peer-to-peer network. Without a bootstrap mechanism, whichever agent happens to call `create_user` first would become admin — an unpredictable race condition in production.
+
+The progenitor pattern solves this by fixing the identity of the first admin at DNA installation time. The founding agent's public key is written into the DNA properties before any agent joins, so the network recognizes exactly who the legitimate first administrator is regardless of join order.
+
+## How It Works
+
+### Step 1: Embedding the progenitor key
+
+Before installing the hApp, the network creator's agent public key is written into `workdir/happ.yaml` under `progenitor_pubkey`. In production, this is done by the Kangaroo (Electron) app, which reads the creator's key from the Holochain conductor admin API.
+
+```yaml
+# workdir/happ.yaml
+properties:
+  progenitor_pubkey: uhCAk...  # base64-encoded AgentPubKey, or ~ for dev mode
+```
+
+### Step 2: First profile creation triggers auto-registration
+
+When any agent calls `create_user`, the `users_organizations` coordinator zome checks whether the caller is the progenitor:
+
+```rust
+// users_organizations::user.rs — simplified
+let is_prog = check_if_progenitor()?;
+let progenitor_configured = DnaProperties::get_progenitor_pubkey()?.is_some();
+let should_auto_register = if progenitor_configured {
+    is_prog  // production: only the progenitor auto-registers
+} else {
+    no_admins_yet.is_empty()  // dev mode: first user auto-registers
+};
+
+if should_auto_register {
+    // cross-zome call to administration::add_administrator
+}
+```
+
+### Step 3: Progenitor bypass in add_administrator
+
+The `add_administrator` function in the `administration` coordinator zome accepts the call from any agent who is either the progenitor or an existing administrator:
+
+```rust
+// administration::administration.rs — simplified
+let is_admin = get_administrators()?.contains(&caller);
+let is_prog  = check_if_progenitor()?;
+let no_admins = get_administrators()?.is_empty();
+
+if !is_admin && !is_prog && !no_admins {
+    return Err(wasm_error!("Unauthorized"));
+}
+```
+
+This means the progenitor can add themselves (and others) to the admin list even before any admin record exists.
+
+## Two Deployment Modes
+
+### Production mode (progenitor key configured)
+
+`progenitor_pubkey` is set to the network creator's actual key.
+
+- Only the progenitor is auto-registered as admin when they call `create_user`.
+- Any other agent who creates a profile first receives standard `Pending` status — not admin.
+- After auto-registration the progenitor can add further administrators via `add_administrator`.
+
+### Dev mode (no progenitor key)
+
+`progenitor_pubkey` is `~` (null) in `workdir/happ.yaml`.
+
+- The very first agent to call `create_user` becomes admin automatically.
+- All subsequent users receive `Pending` status.
+- Useful for local development and integration tests where pre-generating a key adds friction.
+
+## Key Properties
+
+- **Revocable**: The progenitor is a regular administrator. Any other administrator can call `remove_administrator` to remove them. They have no permanent super-admin privilege.
+- **Idempotent**: Calling `add_administrator` for an agent who is already an admin returns `false` without error and creates no duplicate links.
+- **Last-admin protection**: `remove_administrator` rejects the call if it would remove the final administrator from the network (`LastAdminError`).
+- **Coordinator-enforced**: Authorization lives in the coordinator zome only. The integrity zome returns `Valid` unconditionally for `AllAdministrators` links because HDI 0.7.0 does not expose `get_links` inside validation callbacks.
+
+## Configuration
+
+### Development (default)
+
+```yaml
+# workdir/happ.yaml
+properties:
+  progenitor_pubkey: ~
+```
+
+The first agent to register becomes admin. No key management needed.
+
+### Production
+
+Obtain the progenitor's agent public key from the Holochain conductor admin API, encode it as a base64 string, and set it before building the hApp:
+
+```yaml
+# workdir/happ.yaml
+properties:
+  progenitor_pubkey: uhCAkXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Then rebuild:
+
+```bash
+bun build:happ
+```
+
+The Kangaroo desktop app automates this step: it reads the creator's key via the conductor admin WebSocket and injects it into DNA properties at install time.
+
+## API Reference
+
+### `is_progenitor() -> ExternResult<bool>` (administration coordinator)
+
+Returns `true` if the calling agent is the network progenitor. Checks the caller's initial (genesis) agent key against the value stored in DNA properties.
+
+```typescript
+// Frontend usage via administrationService
+const isProgenitor = await administrationService.isProgenitor();
+```
+
+### `add_administrator(input: EntityActionHashAgents) -> ExternResult<bool>` (administration coordinator)
+
+Adds an agent to the administrator list. Returns `true` when a new admin link was created, `false` if already admin.
+
+Authorization gate: caller must be the progenitor or an existing administrator.
+
+### `check_if_progenitor() -> ExternResult<bool>` (utils lib — internal)
+
+Private utility used inside zomes. Compares `agent_info()?.agent_initial_pubkey` against the decoded `progenitor_pubkey` from DNA properties. Not exposed as an extern.
+
+## Writing Tests
+
+### Choosing the right setup helper
+
+Two conductor setup helpers exist in `tests/sweettest/src/common/conductors.rs`:
+
+```rust
+// Use when the test needs progenitor-gated behavior.
+// Alice's key is pre-generated and embedded in DNA properties BEFORE install.
+// Alice becomes admin automatically when she calls create_user.
+let (conductors, alice, bob) = setup_two_agents_with_alice_as_progenitor().await;
+
+// Use when progenitor status is irrelevant to the test.
+// A hardcoded key (HARDCODED_PROGENITOR_PUBKEY) is embedded that neither
+// Alice nor Bob matches — neither is auto-registered as admin.
+let (conductors, alice, bob) = setup_two_agents().await;
+```
+
+Use `setup_two_agents_with_alice_as_progenitor()` for any test that:
+- Requires Alice to be an administrator
+- Tests progenitor detection (`is_progenitor`)
+- Tests `add_administrator` authorization
+
+Use `setup_two_agents()` for tests where admin status should not be granted implicitly.
+
+### Example: testing progenitor auto-registration
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn progenitor_auto_registered_as_admin() {
+    let (conductors, alice, bob) = setup_two_agents_with_alice_as_progenitor().await;
+
+    // Progenitor creates profile — auto-registration fires
+    conductors[0]
+        .call::<_, Record>(&alice.zome("users_organizations"), "create_user", sample_user("Alice"))
+        .await;
+
+    await_consistency(15, [&alice, &bob]).await.unwrap();
+
+    let admins: Vec<AgentPubKey> = conductors[0]
+        .call(&alice.zome("administration"), "get_all_administrators", ())
+        .await;
+
+    assert!(admins.contains(&alice.agent_pubkey()));
+    assert!(!admins.contains(&bob.agent_pubkey()));
+}
+```
+
+The dedicated test suite lives at `tests/sweettest/tests/administration/progenitor.rs`.
+
+## Related Documentation
+
+- [Administration Zome Specification](technical-specs/zomes/administration.md) — detailed zome API
+- [Roles and Permissions](requirements/roles.md) — role assignment context
+- [Backend Zome Functions API](technical-specs/api/backend/zome-functions.md) — complete function reference
+- [Moss/Weave Integration](MOSS_INTEGRATION.md) — progenitor detection in the Weave context
+- [Architecture Overview](architecture/README.md) — network bootstrap in the broader system design

--- a/documentation/technical-specs/api/backend/zome-functions.md
+++ b/documentation/technical-specs/api/backend/zome-functions.md
@@ -198,27 +198,59 @@ Removes a member from an organization.
 **DNA**: `requests_and_offers`  
 **Zome**: `administration`
 
+For the full administration design including the progenitor bootstrap mechanism see [The Progenitor Pattern](../../../progenitor.md) and [Administration Zome Specification](../zomes/administration.md).
+
 ### Functions
 
-#### `promote_to_admin(agent_hash: AgentPubKey) -> ExternResult<()>`
+#### `is_progenitor(_: ()) -> ExternResult<bool>`
 
-Promotes a user to administrator.
+Returns `true` if the calling agent is the network progenitor. Compares the caller's genesis agent key against the `progenitor_pubkey` embedded in DNA properties.
 
-#### `demote_from_admin(agent_hash: AgentPubKey) -> ExternResult<()>`
+**Authorization**: none required — any agent may call this to check their own status.
 
-Demotes an administrator.
+#### `add_administrator(input: EntityActionHashAgents) -> ExternResult<bool>`
 
-#### `promote_to_moderator(agent_hash: AgentPubKey) -> ExternResult<()>`
+Adds one or more agents to the administrator list.
 
-Promotes a user to moderator.
+**Input**:
 
-#### `suspend_user(input: SuspendUserInput) -> ExternResult<()>`
+```rust
+pub struct EntityActionHashAgents {
+    pub original_action_hash: ActionHash,
+    pub previous_action_hash: ActionHash,
+    pub agents: Vec<AgentPubKey>,
+}
+```
 
-Suspends a user with reason.
+**Output**: `true` when a new admin link was created; `false` if the agent is already an administrator (idempotent).
 
-#### `get_all_admins() -> ExternResult<Vec<AgentPubKey>>`
+**Authorization**: caller must be the network progenitor or an existing administrator.
 
-Retrieves all administrators.
+#### `remove_administrator(input: EntityActionHashAgents) -> ExternResult<bool>`
+
+Removes an agent from the administrator list.
+
+**Authorization**: caller must be an existing administrator. Returns `LastAdminError` if removing would leave the network with no administrators.
+
+#### `get_all_administrators() -> ExternResult<Vec<Record>>`
+
+Returns all current administrator records.
+
+#### `get_agent_administration(agent: AgentPubKey) -> ExternResult<Option<Record>>`
+
+Returns the administration record for a specific agent, or `None` if they are not an administrator.
+
+#### `suspend_user(input: SuspendUserInput) -> ExternResult<Record>`
+
+Suspends a user with a reason. Caller must be an administrator.
+
+#### `unsuspend_user(agent: AgentPubKey) -> ExternResult<Record>`
+
+Lifts a suspension. Caller must be an administrator.
+
+#### `update_entity_status(input: UpdateEntityStatusInput) -> ExternResult<Record>`
+
+Updates the status (`Pending`, `Accepted`, `Rejected`, `SuspendedIndefinitely`, `SuspendedTemporarily`) of a user or organization. Caller must be an administrator.
 
 ## Error Handling
 


### PR DESCRIPTION
## Intent

Document the progenitor pattern comprehensively across the project's documentation.

The progenitor pattern was well-implemented in code (136 references, dedicated test suite) but had ~50% documentation coverage. Missing: architecture-level description, getting-started/installation guide, complete API reference, troubleshooting entry, and test helper explanation.

## Changes

### New files
- `documentation/progenitor.md` — standalone deep-dive into the progenitor pattern: what it is, step-by-step flow, production vs dev modes, key properties (revocable, idempotent, last-admin protection), configuration guide, API reference (`is_progenitor`, `add_administrator`, `check_if_progenitor`), and test-writing guide
- `documentation/architecture/README.md` — new architecture overview with component layout, 7-layer summary, and Network Bootstrap section (file was referenced in DOCUMENTATION_INDEX but did not exist)

### Updated files
- `documentation/technical-specs/api/backend/zome-functions.md` — replaced stale admin function signatures (`promote_to_admin`, `demote_from_admin` etc.) with the correct `is_progenitor`, `add_administrator`, `remove_administrator`, and status functions
- `documentation/guides/installation.md` — added Production Network Setup section explaining `progenitor_pubkey` configuration for Kangaroo and manual deployments
- `documentation/TROUBLESHOOTING.md` — added "I created a user but I'm not an administrator" entry with diagnosis steps and solutions for both modes
- `documentation/guides/testing.md` — added explanation of `setup_two_agents_with_alice_as_progenitor` vs `setup_two_agents` and when to use each
- `documentation/DOCUMENTATION_INDEX.md` — added progenitor.md under new Key Patterns section; updated architecture/README.md entry

## How to test

Read `documentation/progenitor.md` and cross-check the Rust snippets against the actual source:
- `dnas/requests_and_offers/coordinator/administration/src/administration.rs` — `add_administrator`, `remove_administrator`, `is_progenitor`
- `dnas/requests_and_offers/coordinator/users_organizations/src/user.rs` — progenitor auto-registration in `create_user`
- `tests/sweettest/tests/administration/progenitor.rs` — verify test helper descriptions match the actual setup functions