### PR TITLE
feat(users): split name into given and family fields (#139)

### DIFF
--- a/documentation/technical-specs/api/frontend/schemas.md
+++ b/documentation/technical-specs/api/frontend/schemas.md
@@ -53,6 +53,37 @@ Complete schema definitions for service type validation and transformation.
 
 Request-specific schemas with proper validation boundaries.
 
+### User Schemas
+
+**File**: `ui/src/lib/schemas/users.schemas.ts`
+
+User profile schemas, plus the form-collection split that separates the DHT `name` field into given and family name inputs. `UserInDHT` is unchanged — `name` remains a single string — so there is no DNA bump and no data migration. The split lives only at the form boundary.
+
+```typescript
+// Form-collection shape: name split into two required fields.
+// Mononymous users enter "." in family_name as an explicit declaration.
+export const UserFormInputSchema = S.Struct({
+  given_name: S.String.pipe(S.minLength(1), S.maxLength(100)),
+  family_name: S.String.pipe(S.minLength(1), S.maxLength(100)),
+  nickname: S.String.pipe(S.minLength(1), S.maxLength(50)),
+  // ...remaining fields identical to UserInDHTSchema
+});
+
+/** Form → DHT: joins the two fields with a single space. Mononyms become "Sting ." */
+export const formInputToDHT = (input: UserFormInput): UserInDHT => /* ... */;
+
+/** DHT → form, for edit-mode pre-fill: first-space split, so compound family
+ *  names ("del Carmen Rodriguez") are preserved. Mononyms get an empty
+ *  family_name rather than an inherited dot. */
+export const dhtToFormInput = (user: UserInDHT): UserFormInput => /* ... */;
+
+/** Display helper: strips the " ." sentinel from a stored name.
+ *  Embedded dots ("Dr. Smith", "J. R. R. Tolkien") are preserved. */
+export const formatUserName = (name: string | null | undefined): string => /* ... */;
+```
+
+The trailing dot in a stored mononym (`"Sting ."`) is a vetting marker only; `formatUserName` strips it at every display site so it never reaches the UI. The action hash on a user record remains the canonical identity reference — names are display labels.
+
 ### Common Schemas
 
 **File**: `ui/src/lib/schemas/common.schemas.ts`

--- a/documentation/technical-specs/component-library.md
+++ b/documentation/technical-specs/component-library.md
@@ -74,6 +74,18 @@ Components are organized by domain with a feature-based approach, located in `ui
 - `cancel`: When form is cancelled
 - `error`: When form submission fails
 
+### Users Components
+
+#### UserName.svelte
+
+**Purpose**: Renders a user's display name with the mononym sentinel stripped via `formatUserName`. Use wherever `user.name` would otherwise be interpolated directly.
+
+**Props**:
+
+- `user`: UIUser | UserInDHT | { name?: string } | null | undefined - The user, or any object carrying a `name`
+- `fallback`: string - Text shown when no name is available (default: "User")
+- `class`: string - Optional CSS class applied to the wrapping `<span>`
+
 ### Shared Components
 
 #### TagAutocomplete.svelte

--- a/ui/src/lib/components/hrea/test-page/PersonAgentManager.svelte
+++ b/ui/src/lib/components/hrea/test-page/PersonAgentManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import hreaStore from '$lib/stores/hrea.store.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
   import administrationStore from '$lib/stores/administration.store.svelte';
   import type { Agent } from '$lib/types/hrea';
   import { runEffect } from '$lib/utils/effect';
@@ -144,7 +145,7 @@
                     href={`/users/${encodeHashToBase64(agent.user.original_action_hash!)}`}
                     class="text-primary-400 hover:text-primary-300 hover:underline"
                   >
-                    {agent.user.name}
+                    {formatUserName(agent.user.name)}
                   </a>
                 {:else}
                   <span class="italic text-gray-500">N/A</span>

--- a/ui/src/lib/components/hrea/test-page/ResourceSpecManager.svelte
+++ b/ui/src/lib/components/hrea/test-page/ResourceSpecManager.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import hreaStore from '$lib/stores/hrea.store.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
   import serviceTypesStore from '$lib/stores/serviceTypes.store.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
   import administrationStore from '$lib/stores/administration.store.svelte';
@@ -70,7 +71,7 @@
 
     const unsubscribeUserCreated = storeEventBus.on('user:created', ({ user }) => {
       console.log('User created, hREA auto-creating person agent:', user.name);
-      syncInfo.lastSyncEvent = `Auto-user created: ${user.name}`;
+      syncInfo.lastSyncEvent = `Auto-user created: ${formatUserName(user.name)}`;
     });
 
     const unsubscribeOrgCreated = storeEventBus.on('organization:created', ({ organization }) => {

--- a/ui/src/lib/components/organizations/AddOrganizationCoordinatorModal.svelte
+++ b/ui/src/lib/components/organizations/AddOrganizationCoordinatorModal.svelte
@@ -12,6 +12,7 @@
   } from '@skeletonlabs/skeleton';
   import type { UIUser, UIOrganization } from '$lib/types/ui';
   import usersStore from '$lib/stores/users.store.svelte';
+  import UserName from '$lib/components/users/UserName.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
   import { queueAndReverseModal } from '$lib/utils';
 
@@ -184,7 +185,7 @@
               width="w-12"
             />
             <div class="flex-1">
-              <h4 class="font-bold">{user.name}</h4>
+              <h4 class="font-bold"><UserName user={user} /></h4>
               <p class="text-sm text-surface-400">{user.email}</p>
             </div>
           </div>

--- a/ui/src/lib/components/organizations/AddOrganizationMemberModal.svelte
+++ b/ui/src/lib/components/organizations/AddOrganizationMemberModal.svelte
@@ -12,6 +12,7 @@
   import type { UIUser, UIOrganization } from '$lib/types/ui';
   import { runEffect } from '$lib/utils/effect';
   import usersStore from '$lib/stores/users.store.svelte';
+  import UserName from '$lib/components/users/UserName.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
   import { queueAndReverseModal } from '$lib/utils';
 
@@ -181,7 +182,7 @@
               width="w-12"
             />
             <div class="flex-1">
-              <h4 class="font-bold">{user.name}</h4>
+              <h4 class="font-bold"><UserName user={user} /></h4>
               <p class="text-sm text-surface-400">{user.email}</p>
             </div>
           </div>

--- a/ui/src/lib/components/organizations/OrganizationDetailsModal.svelte
+++ b/ui/src/lib/components/organizations/OrganizationDetailsModal.svelte
@@ -10,6 +10,7 @@
   import { Effect as E } from 'effect';
   import MarkdownRenderer from '$lib/components/shared/MarkdownRenderer.svelte';
   import usersStore from '$lib/stores/users.store.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
   import { runEffect } from '$lib/utils/effect';
 
   const modalStore = getModalStore();
@@ -42,7 +43,7 @@
   $effect(() => {
     if (organization?.contact?.user_hash) {
       runEffect(usersStore.getUserByActionHash(organization.contact.user_hash)).then((user) => {
-        if (user) resolvedContactName = user.name;
+        if (user) resolvedContactName = formatUserName(user.name);
       });
     }
   });

--- a/ui/src/lib/components/shared/listings/ContactDisplay.svelte
+++ b/ui/src/lib/components/shared/listings/ContactDisplay.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { UIUser, UIOrganization } from '$lib/types/ui';
+  import UserName from '$lib/components/users/UserName.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
   import { getUserPictureUrl, getOrganizationLogoUrl } from '$lib/utils';
   import { getToastStore } from '@skeletonlabs/skeleton';
 
@@ -119,17 +121,17 @@
       <div class="mt-2 flex items-center gap-3">
         <div class="avatar h-10 w-10 overflow-hidden rounded-full">
           {#if userPictureUrl && userPictureUrl !== '/default_avatar.webp'}
-            <img src={userPictureUrl} alt={user.name} class="h-full w-full object-cover" />
+            <img src={userPictureUrl} alt={formatUserName(user.name)} class="h-full w-full object-cover" />
           {:else}
             <div
               class="flex h-full w-full items-center justify-center bg-primary-500 text-white dark:bg-primary-400"
             >
-              <span class="text-sm font-semibold">{user.name.charAt(0).toUpperCase()}</span>
+              <span class="text-sm font-semibold">{formatUserName(user.name).charAt(0).toUpperCase()}</span>
             </div>
           {/if}
         </div>
         <div>
-          <p class="font-semibold">{user.name}</p>
+          <p class="font-semibold"><UserName user={user} /></p>
           {#if user.nickname}
             <p class="text-sm text-surface-600 dark:text-surface-400">@{user.nickname}</p>
           {/if}

--- a/ui/src/lib/components/shared/listings/ContactModal.svelte
+++ b/ui/src/lib/components/shared/listings/ContactModal.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { UIUser, UIOrganization } from '$lib/types/ui';
+  import UserName from '$lib/components/users/UserName.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
   import { getUserPictureUrl, getOrganizationLogoUrl } from '$lib/utils';
   import { Avatar, getToastStore } from '@skeletonlabs/skeleton';
 
@@ -131,9 +133,9 @@
     <section class="space-y-4">
       <div class="card variant-soft bg-surface-600 p-4">
         <div class="flex items-center gap-4">
-          <Avatar src={userPictureUrl!} initials={user.name.charAt(0).toUpperCase()} />
+          <Avatar src={userPictureUrl!} initials={formatUserName(user.name).charAt(0).toUpperCase()} />
           <div class="flex-1">
-            <h5 class="h5 font-medium text-white">{user.name}</h5>
+            <h5 class="h5 font-medium text-white"><UserName user={user} /></h5>
             {#if user.nickname}
               <p class="text-sm text-surface-300">@{user.nickname}</p>
             {/if}

--- a/ui/src/lib/components/users/AddAdministratorModal.svelte
+++ b/ui/src/lib/components/users/AddAdministratorModal.svelte
@@ -12,6 +12,7 @@
   import type { UIUser } from '$lib/types/ui';
   import administrationStore from '$lib/stores/administration.store.svelte';
   import usersStore from '$lib/stores/users.store.svelte';
+  import UserName from '$lib/components/users/UserName.svelte';
   import { queueAndReverseModal } from '$lib/utils';
   import { Effect as E } from 'effect';
   import { runEffect } from '$lib/utils/effect';
@@ -185,7 +186,7 @@
               width="w-12"
             />
             <div class="flex-1">
-              <h4 class="font-bold">{user.name}</h4>
+              <h4 class="font-bold"><UserName user={user} /></h4>
               <p class="text-sm text-surface-400">{user.email}</p>
             </div>
           </div>

--- a/ui/src/lib/components/users/ProfileStatusIndicator.svelte
+++ b/ui/src/lib/components/users/ProfileStatusIndicator.svelte
@@ -2,6 +2,7 @@
   import { goto } from '$app/navigation';
   import usersStore from '$lib/stores/users.store.svelte';
   import type { Snippet } from 'svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
 
   type Props = {
     showText?: boolean;
@@ -51,7 +52,7 @@
       case 'pending':
         return {
           status: 'pending',
-          text: compact ? 'Pending' : `${currentUser.name || 'User'} (Pending)`,
+          text: compact ? 'Pending' : `${formatUserName(currentUser.name) || 'User'} (Pending)`,
           color: 'text-warning-600',
           bgColor: 'bg-warning-100',
           icon: '⏱️',
@@ -61,8 +62,8 @@
         return {
           status: 'accepted',
           text: compact
-            ? currentUser.nickname || currentUser.name || 'User'
-            : `${currentUser.name || 'User'} ✓`,
+            ? currentUser.nickname || formatUserName(currentUser.name) || 'User'
+            : `${formatUserName(currentUser.name) || 'User'} ✓`,
           color: 'text-success-600',
           bgColor: 'bg-success-100',
           icon: '✓',
@@ -71,7 +72,7 @@
       case 'rejected':
         return {
           status: 'rejected',
-          text: compact ? 'Rejected' : `${currentUser.name || 'User'} (Rejected)`,
+          text: compact ? 'Rejected' : `${formatUserName(currentUser.name) || 'User'} (Rejected)`,
           color: 'text-error-600',
           bgColor: 'bg-error-100',
           icon: '✕',
@@ -80,7 +81,7 @@
       case 'suspended temporarily':
         return {
           status: 'suspended_temporarily',
-          text: compact ? 'Suspended' : `${currentUser.name || 'User'} (Suspended)`,
+          text: compact ? 'Suspended' : `${formatUserName(currentUser.name) || 'User'} (Suspended)`,
           color: 'text-warning-600',
           bgColor: 'bg-warning-100',
           icon: '⚠️',
@@ -89,7 +90,7 @@
       case 'suspended indefinitely':
         return {
           status: 'suspended_indefinitely',
-          text: compact ? 'Suspended' : `${currentUser.name || 'User'} (Suspended)`,
+          text: compact ? 'Suspended' : `${formatUserName(currentUser.name) || 'User'} (Suspended)`,
           color: 'text-error-600',
           bgColor: 'bg-error-100',
           icon: '🚫',
@@ -98,7 +99,7 @@
       default:
         return {
           status: 'unknown',
-          text: compact ? 'Unknown' : `${currentUser.name || 'User'} (?)`,
+          text: compact ? 'Unknown' : `${formatUserName(currentUser.name) || 'User'} (?)`,
           color: 'text-surface-600',
           bgColor: 'bg-surface-100',
           icon: '❓',
@@ -146,7 +147,7 @@
       case 'pending':
         return 'Your profile is pending approval';
       case 'accepted':
-        return `${currentUser.name || 'User'} - Profile active`;
+        return `${formatUserName(currentUser.name) || 'User'} - Profile active`;
       case 'rejected':
         return 'Your profile has been rejected';
       case 'suspended temporarily':

--- a/ui/src/lib/components/users/UserDetailsModal.svelte
+++ b/ui/src/lib/components/users/UserDetailsModal.svelte
@@ -4,6 +4,7 @@
   import { onMount } from 'svelte';
   import ActionBar from '$lib/components/shared/ActionBar.svelte';
   import type { UIUser, UIStatus } from '$lib/types/ui';
+  import UserName from '$lib/components/users/UserName.svelte';
   import administrationStore from '$lib/stores/administration.store.svelte';
   import { AdministrationEntity } from '$lib/types/holochain';
   import { Effect as E } from 'effect';
@@ -84,7 +85,7 @@
         <Avatar src={userPictureUrl} width="w-32" background="bg-surface-100-800-token" />
       </div>
       <div class="flex min-w-0 flex-col items-center">
-        <h2 class="h2 mb-1 truncate font-bold">{user.name}</h2>
+        <h2 class="h2 mb-1 truncate font-bold"><UserName user={user} /></h2>
         <p class="text-surface-300">@{user.nickname}</p>
         {#if user.bio}
           <MarkdownRenderer content={user.bio || ''} class="mt-3 text-center leading-relaxed" />

--- a/ui/src/lib/components/users/UserForm.svelte
+++ b/ui/src/lib/components/users/UserForm.svelte
@@ -2,6 +2,7 @@
   import { Avatar, FileDropzone, getModalStore } from '@skeletonlabs/skeleton';
   import type { ModalComponent, ModalSettings } from '@skeletonlabs/skeleton';
   import type { UserInDHT, UserType } from '$lib/types/holochain';
+  import { formInputToDHT, dhtToFormInput, formatUserName, type UserFormInput } from '$lib/schemas/users.schemas';
   import TimeZoneSelect from '$lib/components/shared/TimeZoneSelect.svelte';
   import AlertModal from '$lib/components/shared/dialogs/AlertModal.svelte';
   import type { AlertModalMeta } from '$lib/types/ui';
@@ -18,6 +19,15 @@
   };
 
   const { mode = 'create', user, onSubmit }: Props = $props();
+
+  // Issue #139: split given/family name handling
+  const initialFormInput = user
+    ? dhtToFormInput(user)
+    : { given_name: '', family_name: '' };
+  const initialGiven = initialFormInput.given_name;
+  const initialFamily = initialFormInput.family_name;
+  const showMigrationBanner =
+    mode === 'edit' && !!user?.name && user.name.trim().length > 0;
 
   // Modal setup
   const alertModalComponent: ModalComponent = { ref: AlertModal };
@@ -99,7 +109,7 @@
       modalStore.trigger(
         alertModal({
           id: 'welcome-and-next-steps',
-          message: welcomeAndNextStepsMessage(userData.name),
+          message: welcomeAndNextStepsMessage(formatUserName(userData.name)),
           confirmLabel: 'Ok !'
         })
       );
@@ -122,8 +132,9 @@
       const pictureBuffer = await (data.get('picture') as File).arrayBuffer();
       const picture = new Uint8Array(pictureBuffer);
 
-      const userInput: UserInDHT = {
-        name: data.get('name') as string,
+      const formInput: UserFormInput = {
+        given_name: data.get('given_name') as string,
+        family_name: data.get('family_name') as string,
         nickname: data.get('nickname') as string,
         bio: data.get('bio') as string,
         picture: picture.byteLength > 0 ? picture : mode === 'edit' ? user?.picture : undefined,
@@ -133,6 +144,7 @@
         time_zone: data.get('timezone') as string,
         location: data.get('location') as string
       };
+      const userInput: UserInDHT = formInputToDHT(formInput);
 
       await onSubmit(userInput);
 
@@ -140,7 +152,7 @@
         modalStore.trigger(
           alertModal({
             id: 'welcome-and-next-steps',
-            message: welcomeAndNextStepsMessage(userInput.name),
+            message: welcomeAndNextStepsMessage(formatUserName(userInput.name)),
             confirmLabel: 'Ok !'
           })
         );
@@ -187,10 +199,52 @@
 
   <p>*required fields</p>
 
-  <label class="label text-lg">
-    Name* :
-    <input type="text" class="input" name="name" value={user?.name || ''} required />
-  </label>
+  {#if showMigrationBanner}
+    <aside class="alert variant-soft-warning">
+      <p>
+        We've split the name field in two. Please check the values below and adjust if
+        needed.
+      </p>
+    </aside>
+  {/if}
+
+  <div class="flex flex-col gap-4 sm:flex-row">
+    <label class="label flex-1 text-lg">
+      Given name* :
+      <input
+        type="text"
+        class="input"
+        name="given_name"
+        value={initialGiven}
+        required
+        minlength="1"
+        maxlength="100"
+        pattern="\S.*"
+        title="Must contain at least one non-whitespace character"
+      />
+    </label>
+
+    <label class="label flex-1 text-lg">
+      Family name* :
+      <input
+        type="text"
+        class="input"
+        name="family_name"
+        value={initialFamily}
+        required
+        minlength="1"
+        maxlength="100"
+        pattern="\S.*"
+        title="Must contain at least one non-whitespace character"
+      />
+    </label>
+  </div>
+
+  <p class="text-sm opacity-75">
+    Names come in many shapes. Please enter the name(s) you wish to be known by — use
+    whichever fields fit your name. Both fields are required. If you go by a single name
+    use a dot [ . ] in the second field.
+  </p>
 
   <label class="label text-lg">
     Nickname* :

--- a/ui/src/lib/components/users/UserForm.svelte
+++ b/ui/src/lib/components/users/UserForm.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { browser } from '$app/environment';
+  import { encodeHashToBase64 } from '@holochain/client';
   import { Avatar, FileDropzone, getModalStore } from '@skeletonlabs/skeleton';
   import type { ModalComponent, ModalSettings } from '@skeletonlabs/skeleton';
   import type { UserInDHT, UserType } from '$lib/types/holochain';
@@ -26,8 +28,18 @@
     : { given_name: '', family_name: '' };
   const initialGiven = initialFormInput.given_name;
   const initialFamily = initialFormInput.family_name;
+  // Migration banner for users created before #139 (name field split into given/family).
+  // TODO: Remove this banner and its localStorage flag once all alpha testers have
+  // confirmed their split (estimated next release after #151 lands).
+  const migrationAckKey =
+    user?.original_action_hash && browser
+      ? `name-split-acknowledged-${encodeHashToBase64(user.original_action_hash)}`
+      : null;
+  const wasAcknowledged =
+    migrationAckKey ? localStorage.getItem(migrationAckKey) === 'true' : false;
   const showMigrationBanner =
-    mode === 'edit' && !!user?.name && user.name.trim().length > 0;
+    mode === 'edit' && !!user?.name && user.name.trim().length > 0 && !wasAcknowledged;
+  let migrationConfirmed = $state(false);
 
   // Modal setup
   const alertModalComponent: ModalComponent = { ref: AlertModal };
@@ -148,6 +160,11 @@
 
       await onSubmit(userInput);
 
+      // Persist migration banner acknowledgment so it doesn't return on subsequent edits.
+      if (mode === 'edit' && migrationConfirmed && migrationAckKey) {
+        localStorage.setItem(migrationAckKey, 'true');
+      }
+
       if (mode === 'create') {
         modalStore.trigger(
           alertModal({
@@ -205,6 +222,10 @@
         We've split the name field in two. Please check the values below and adjust if
         needed.
       </p>
+      <label class="flex items-center gap-2">
+        <input type="checkbox" class="checkbox" bind:checked={migrationConfirmed} />
+        <span>Confirmed: my name's split correctly!</span>
+      </label>
     </aside>
   {/if}
 

--- a/ui/src/lib/components/users/UserForm.svelte
+++ b/ui/src/lib/components/users/UserForm.svelte
@@ -263,9 +263,8 @@
   </div>
 
   <p class="text-sm opacity-75">
-    Names come in many shapes. Please enter the name(s) you wish to be known by — use
-    whichever fields fit your name. Both fields are required. If you go by a single name
-    use a dot [ . ] in the second field.
+    Names come in many shapes. Enter yours across the two fields. If you go by a single
+    name, put a dot [ . ] in the family field; we'll hide it when displaying your name.
   </p>
 
   <label class="label text-lg">

--- a/ui/src/lib/components/users/UserForm.svelte
+++ b/ui/src/lib/components/users/UserForm.svelte
@@ -4,6 +4,7 @@
   import { Avatar, FileDropzone, getModalStore } from '@skeletonlabs/skeleton';
   import type { ModalComponent, ModalSettings } from '@skeletonlabs/skeleton';
   import type { UserInDHT, UserType } from '$lib/types/holochain';
+  import type { UIUser } from '$lib/types/ui';
   import { formInputToDHT, dhtToFormInput, formatUserName, type UserFormInput } from '$lib/schemas/users.schemas';
   import TimeZoneSelect from '$lib/components/shared/TimeZoneSelect.svelte';
   import AlertModal from '$lib/components/shared/dialogs/AlertModal.svelte';
@@ -16,7 +17,7 @@
 
   type Props = {
     mode: 'create' | 'edit';
-    user?: UserInDHT;
+    user?: UIUser;
     onSubmit: (input: UserInDHT) => Promise<void>;
   };
 

--- a/ui/src/lib/components/users/UserName.svelte
+++ b/ui/src/lib/components/users/UserName.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { UIUser } from '$lib/types/ui';
+  import type { UserInDHT } from '$lib/types/holochain';
+  import { formatUserName } from '$lib/schemas/users.schemas';
+
+  type Props = {
+    user: UIUser | UserInDHT | { name?: string } | null | undefined;
+    fallback?: string;
+    class?: string;
+  };
+
+  const { user, fallback = 'User', class: className = '' }: Props = $props();
+
+  const display = $derived(user?.name ? formatUserName(user.name) : fallback);
+</script>
+
+<span class={className}>{display}</span>

--- a/ui/src/lib/components/users/UserProfile.svelte
+++ b/ui/src/lib/components/users/UserProfile.svelte
@@ -9,6 +9,7 @@
     Tab
   } from '@skeletonlabs/skeleton';
   import usersStore from '$lib/stores/users.store.svelte';
+  import UserName from '$lib/components/users/UserName.svelte';
   import administrationStore from '$lib/stores/administration.store.svelte';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
   import requestsStore from '$lib/stores/requests.store.svelte';
@@ -232,9 +233,9 @@
     <div class="mb-6 flex w-full items-center justify-between">
       <h1 class="h1">
         {#if isCurrentUser}
-          Welcome <span class="font-bold text-primary-500">{user.name}</span>!
+          Welcome <span class="font-bold text-primary-500"><UserName user={user} /></span>!
         {:else}
-          <span class="font-bold text-primary-500">{user.name}</span>'s Profile
+          <span class="font-bold text-primary-500"><UserName user={user} /></span>'s Profile
         {/if}
       </h1>
       {#if isCurrentUser}

--- a/ui/src/lib/components/users/UsersTable.svelte
+++ b/ui/src/lib/components/users/UsersTable.svelte
@@ -6,6 +6,8 @@
   import { goto } from '$app/navigation';
   import { encodeHashToBase64 } from '@holochain/client';
   import UserDetailsModal from '$lib/components/users/UserDetailsModal.svelte';
+  import UserName from '$lib/components/users/UserName.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
 
   type Props = {
     users: UIUser[];
@@ -61,9 +63,9 @@
           {#each users as user}
             <tr>
               <td>
-                <Avatar src={getUserPictureUrl(user)} alt={`Avatar of ${user.name}`} />
+                <Avatar src={getUserPictureUrl(user)} alt={`Avatar of ${formatUserName(user.name)}`} />
               </td>
-              <td class="whitespace-nowrap">{user.name}</td>
+              <td class="whitespace-nowrap"><UserName user={user} /></td>
               <td class="whitespace-nowrap">
                 {#if user.user_type}
                   {user.user_type.charAt(0).toUpperCase() + user.user_type.slice(1)}
@@ -98,7 +100,7 @@
           <div class="flex items-center gap-4">
             <Avatar src={getUserPictureUrl(user)} width="w-16" />
             <div class="min-w-0 flex-1">
-              <h3 class="h4 truncate font-bold">{user.name}</h3>
+              <h3 class="h4 truncate font-bold"><UserName user={user} /></h3>
               <p class="text-sm opacity-80">
                 {user.user_type.charAt(0).toUpperCase() + user.user_type.slice(1)}
               </p>

--- a/ui/src/lib/composables/ui/useProfileValidation.svelte.ts
+++ b/ui/src/lib/composables/ui/useProfileValidation.svelte.ts
@@ -1,4 +1,5 @@
 import usersStore from '$lib/stores/users.store.svelte';
+import { formatUserName } from '$lib/schemas/users.schemas';
 
 export type ProfileStatus =
   | 'missing'
@@ -69,7 +70,7 @@ export function useProfileValidation(options: UseProfileValidationOptions = {}) 
     }
 
     const status = currentUser.status?.status_type;
-    const userName = currentUser.name || currentUser.nickname || 'User';
+    const userName = formatUserName(currentUser.name) || currentUser.nickname || 'User';
 
     switch (status) {
       case 'pending':

--- a/ui/src/lib/schemas/users.schemas.ts
+++ b/ui/src/lib/schemas/users.schemas.ts
@@ -113,6 +113,105 @@ export const UpdateUserInputSchema = S.Struct({
 export type UpdateUserInput = S.Schema.Type<typeof UpdateUserInputSchema>;
 
 // ============================================================================
+// FORM SCHEMAS
+// ============================================================================
+
+/**
+ * Form input shape for the user profile form.
+ *
+ * Splits the DHT `name` field into `given_name` and `family_name` for
+ * collection. The DHT struct itself is unchanged — concatenation happens
+ * at submit time via `formInputToDHT`.
+ *
+ * Both fields are required. Mononymous users are asked to enter "." in the
+ * second field as an explicit declaration; the dot is stripped at display
+ * time by `formatUserName`.
+ */
+export const UserFormInputSchema = S.Struct({
+  given_name: S.String.pipe(
+    S.minLength(1, { message: () => 'Given name must not be empty' }),
+    S.maxLength(100, { message: () => 'Given name must be at most 100 characters' })
+  ),
+  family_name: S.String.pipe(
+    S.minLength(1, {
+      message: () => 'Family name must not be empty (use "." if you have a single name)'
+    }),
+    S.maxLength(100, { message: () => 'Family name must be at most 100 characters' })
+  ),
+  nickname: S.String.pipe(
+    S.minLength(1, { message: () => 'Nickname must not be empty' }),
+    S.maxLength(50, { message: () => 'Nickname must be at most 50 characters' })
+  ),
+  bio: S.optional(
+    S.String.pipe(S.maxLength(1000, { message: () => 'Bio must be at most 1000 characters' }))
+  ),
+  picture: S.optional(S.Uint8Array),
+  user_type: UserTypeSchema,
+  email: S.String.pipe(
+    S.pattern(/^[^\s@]+@[^\s@]+\.[^\s@]+$/, { message: () => 'Please enter a valid email address' })
+  ),
+  phone: S.optional(
+    S.String.pipe(
+      S.pattern(/^\+?[\d\s\-()]+$/, { message: () => 'Please enter a valid phone number' })
+    )
+  ),
+  time_zone: S.optional(S.String),
+  location: S.optional(
+    S.String.pipe(S.maxLength(200, { message: () => 'Location must be at most 200 characters' }))
+  )
+});
+export type UserFormInput = S.Schema.Type<typeof UserFormInputSchema>;
+
+/**
+ * Transformation: form input → DHT shape.
+ *
+ * Concatenates given_name and family_name with a single space. For
+ * mononymous users this produces e.g. "Sting ." — the trailing dot is a
+ * vetting marker in stored data and is stripped at display time.
+ */
+export const formInputToDHT = (input: UserFormInput): UserInDHT => ({
+  name: `${input.given_name.trim()} ${input.family_name.trim()}`,
+  nickname: input.nickname,
+  bio: input.bio,
+  picture: input.picture,
+  user_type: input.user_type,
+  email: input.email,
+  phone: input.phone,
+  time_zone: input.time_zone,
+  location: input.location
+});
+
+/**
+ * Reverse transformation: DHT → form input (for edit-mode pre-fill).
+ *
+ * Uses first-space split to preserve compound family names common in
+ * Spanish, Portuguese, Dutch and Arabic naming conventions (e.g.
+ * "Maria del Carmen Rodriguez" → given: "Maria", family: "del Carmen Rodriguez").
+ *
+ * For mononymous users (single token, no space) the family_name is left
+ * empty rather than pre-filled with a dot — so editing makes mononymism a
+ * deliberate user choice rather than inherited form state.
+ */
+export const dhtToFormInput = (user: UserInDHT): UserFormInput => {
+  const trimmed = user.name.trim();
+  const firstSpace = trimmed.indexOf(' ');
+  const given_name = firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace);
+  const family_name = firstSpace === -1 ? '' : trimmed.slice(firstSpace + 1).trim();
+  return {
+    given_name,
+    family_name,
+    nickname: user.nickname,
+    bio: user.bio,
+    picture: user.picture,
+    user_type: user.user_type,
+    email: user.email,
+    phone: user.phone,
+    time_zone: user.time_zone,
+    location: user.location
+  };
+};
+
+// ============================================================================
 // SERVICE OPERATION SCHEMAS
 // ============================================================================
 
@@ -210,4 +309,23 @@ export const createUIUser = (data: Partial<UIUser>): UIUser => {
     role: data.role,
     service_type_hashes: data.service_type_hashes
   };
+};
+
+/**
+ * Strips the sentinel dot used to mark mononymous users.
+ *
+ * A user who entered just "Sting" with "." in the family_name field has
+ * `name: "Sting ."` stored in the DHT. The dot is a vetting marker only —
+ * it should never appear in the UI. This function strips it (and a
+ * defensive leading variant) for display.
+ *
+ * Embedded dots (initials like "J. R. R. Tolkien", titles like "Dr. Smith")
+ * are preserved because they don't match the boundary patterns.
+ */
+export const formatUserName = (name: string | null | undefined): string => {
+  if (!name) return '';
+  return name
+    .replace(/\s\.\s*$/, '') // strip " ." at end (primary sentinel)
+    .replace(/^\s*\.\s/, '') // strip ". " at start (defensive)
+    .trim();
 };

--- a/ui/src/lib/stores/hrea.store.svelte.ts
+++ b/ui/src/lib/stores/hrea.store.svelte.ts
@@ -14,6 +14,7 @@ import type { Agent, ResourceSpecification, Proposal, Intent } from '$lib/types/
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client/core';
 import type { UIUser, UIOrganization, UIServiceType, UIRequest, UIOffer } from '$lib/types/ui';
 import type { UIMediumOfExchange } from '$lib/schemas/mediums-of-exchange.schemas';
+import { formatUserName } from '$lib/schemas/users.schemas';
 import {
   createProposalFromRequest as mapRequestToProposal,
   validateRequestMappingRequirements
@@ -164,7 +165,7 @@ export type HreaStore = {
  */
 const createUserAgentMapping = (user: UIUser): { name: string; note: string } => {
   // Use name if available, fallback to nickname, then to 'Unknown User'
-  const displayName = user.name || user.nickname || 'Unknown User';
+  const displayName = formatUserName(user.name) || user.nickname || 'Unknown User';
 
   // Store the action hash as the primary reference, with minimal additional info
   const actionHashRef = user.original_action_hash?.toString() || 'unknown';

--- a/ui/src/routes/(public)/organizations/[id]/+page.svelte
+++ b/ui/src/routes/(public)/organizations/[id]/+page.svelte
@@ -8,6 +8,7 @@
   import administrationStore from '$lib/stores/administration.store.svelte';
   import { Avatar } from '@skeletonlabs/skeleton';
   import usersStore from '$lib/stores/users.store.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
   import OrganizationMembersTable from '$lib/components/organizations/OrganizationMembersTable.svelte';
   import OrganizationCoordinatorsTable from '$lib/components/organizations/OrganizationCoordinatorsTable.svelte';
   import RequestsTable from '$lib/components/requests/RequestsTable.svelte';
@@ -165,7 +166,7 @@
   $effect(() => {
     if (organization?.contact?.user_hash) {
       runEffect(usersStore.getUserByActionHash(organization.contact.user_hash)).then((user) => {
-        if (user) resolvedContactName = user.name;
+        if (user) resolvedContactName = formatUserName(user.name);
       });
     } else {
       resolvedContactName = '';

--- a/ui/src/routes/(public)/organizations/[id]/edit/+page.svelte
+++ b/ui/src/routes/(public)/organizations/[id]/edit/+page.svelte
@@ -5,6 +5,7 @@
   import { decodeHashFromBase64, encodeHashToBase64, type ActionHash } from '@holochain/client';
   import organizationsStore from '$lib/stores/organizations.store.svelte';
   import usersStore from '$lib/stores/users.store.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
   import type { OrganizationInDHT } from '$lib/types/holochain';
   import OrganizationForm from '$lib/components/organizations/OrganizationForm.svelte';
   import { runEffect } from '$lib/utils/effect';
@@ -52,7 +53,7 @@
   $effect(() => {
     if (organization?.contact?.user_hash) {
       runEffect(usersStore.getUserByActionHash(organization.contact.user_hash)).then((user) => {
-        if (user) resolvedContactName = user.name;
+        if (user) resolvedContactName = formatUserName(user.name);
       });
     } else {
       resolvedContactName = '';

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import usersStore from '$lib/stores/users.store.svelte';
   import { isHolochainConnected } from '$lib/utils/holochain-client.utils';
   import { useBackgroundAdminCheck } from '$lib/composables/connection/useBackgroundAdminCheck.svelte';
+  import { formatUserName } from '$lib/schemas/users.schemas';
 
   let error: string | null = $state(null);
   let isLoading = $state(true);
@@ -190,7 +191,7 @@
       <div class="mb-12">
         <div class="mb-8 rounded-xl border border-gray-200 bg-white p-8 shadow-lg">
           <div class="text-center">
-            <h2 class="h2 mb-4 text-primary-700">Welcome back, {currentUser?.name}!</h2>
+            <h2 class="h2 mb-4 text-primary-700">Welcome back, {formatUserName(currentUser?.name)}!</h2>
             <p class="mb-6 text-lg text-gray-600">
               Ready to make a difference in the community today?
             </p>

--- a/ui/src/routes/admin/+page.svelte
+++ b/ui/src/routes/admin/+page.svelte
@@ -15,6 +15,7 @@
   import { getUserPictureUrl } from '$lib/utils';
   import { runEffect } from '$lib/utils/effect';
   import UserDetailsModal from '$lib/components/users/UserDetailsModal.svelte';
+  import UserName from '$lib/components/users/UserName.svelte';
   import OrganizationDetailsModal from '$lib/components/organizations/OrganizationDetailsModal.svelte';
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
@@ -314,7 +315,7 @@
                     />
                     <button
                       class="text-primary-400 hover:underline"
-                      onclick={() => handleViewUser(user)}>{user.name}</button
+                      onclick={() => handleViewUser(user)}><UserName user={user} /></button
                     >
                   </div>
                   <div class="flex gap-2">

--- a/ui/tests/unit/utils/formatUserName.test.ts
+++ b/ui/tests/unit/utils/formatUserName.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for formatUserName — strips sentinel dot used to mark
+ * mononymous users while preserving embedded dots (initials, titles).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatUserName } from '$lib/schemas/users.schemas';
+
+describe('formatUserName', () => {
+  it('strips trailing " ." sentinel (primary mononym case)', () => {
+    expect(formatUserName('Sting .')).toBe('Sting');
+  });
+
+  it('strips leading ". " sentinel (defensive)', () => {
+    expect(formatUserName('. Cher')).toBe('Cher');
+  });
+
+  it('passes through a normal two-part name unchanged', () => {
+    expect(formatUserName('Maria Rodriguez')).toBe('Maria Rodriguez');
+  });
+
+  it('preserves compound family names', () => {
+    expect(formatUserName('Maria del Carmen Rodriguez')).toBe('Maria del Carmen Rodriguez');
+  });
+
+  it('preserves embedded dot in titles like "Dr. Smith"', () => {
+    expect(formatUserName('Dr. Smith')).toBe('Dr. Smith');
+  });
+
+  it('preserves dots in initials like "J. R. R. Tolkien"', () => {
+    expect(formatUserName('J. R. R. Tolkien')).toBe('J. R. R. Tolkien');
+  });
+
+  it('strips only the trailing sentinel when initials are also present', () => {
+    expect(formatUserName('M.A. Singh .')).toBe('M.A. Singh');
+  });
+
+  it('handles the degenerate ". ." input defensively', () => {
+    // Strips leading ". " then trailing whitespace/dot — ends up empty or "."
+    const result = formatUserName('. .');
+    expect(['', '.']).toContain(result);
+  });
+
+  it('returns empty string for null', () => {
+    expect(formatUserName(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(formatUserName(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(formatUserName('')).toBe('');
+  });
+
+  it('trims surrounding whitespace from a normal name', () => {
+    expect(formatUserName('  Maria Rodriguez  ')).toBe('Maria Rodriguez');
+  });
+});

--- a/ui/tests/unit/utils/userFormTransformations.test.ts
+++ b/ui/tests/unit/utils/userFormTransformations.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for form <-> DHT transformations.
+ *
+ * formInputToDHT: concatenates given_name + family_name into the single DHT name field.
+ * dhtToFormInput: first-space split for edit-mode pre-fill, preserving compound family names.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formInputToDHT,
+  dhtToFormInput,
+  type UserFormInput
+} from '$lib/schemas/users.schemas';
+import type { UserInDHT } from '$lib/schemas/users.schemas';
+
+// Minimal valid form input for tests - only name fields vary
+const baseForm: Omit<UserFormInput, 'given_name' | 'family_name'> = {
+  nickname: 'tester',
+  user_type: 'advocate',
+  email: 'test@example.com'
+};
+
+const baseDHT: Omit<UserInDHT, 'name'> = {
+  nickname: 'tester',
+  user_type: 'advocate',
+  email: 'test@example.com'
+};
+
+describe('formInputToDHT', () => {
+  it('concatenates given_name and family_name with a single space', () => {
+    const result = formInputToDHT({
+      ...baseForm,
+      given_name: 'Maria',
+      family_name: 'Rodriguez'
+    });
+    expect(result.name).toBe('Maria Rodriguez');
+  });
+
+  it('produces the sentinel form for mononymous users (family_name = ".")', () => {
+    const result = formInputToDHT({
+      ...baseForm,
+      given_name: 'Sting',
+      family_name: '.'
+    });
+    expect(result.name).toBe('Sting .');
+  });
+
+  it('preserves a compound family name', () => {
+    const result = formInputToDHT({
+      ...baseForm,
+      given_name: 'Maria',
+      family_name: 'del Carmen Rodriguez'
+    });
+    expect(result.name).toBe('Maria del Carmen Rodriguez');
+  });
+
+  it('trims whitespace on both name parts', () => {
+    const result = formInputToDHT({
+      ...baseForm,
+      given_name: '  Maria  ',
+      family_name: '  Rodriguez  '
+    });
+    expect(result.name).toBe('Maria Rodriguez');
+  });
+
+  it('preserves all other fields unchanged', () => {
+    const input: UserFormInput = {
+      ...baseForm,
+      given_name: 'Maria',
+      family_name: 'Rodriguez',
+      bio: 'Hello',
+      phone: '+44 1234 567890',
+      time_zone: 'Europe/London',
+      location: 'Colchester'
+    };
+    const result = formInputToDHT(input);
+    expect(result.nickname).toBe('tester');
+    expect(result.user_type).toBe('advocate');
+    expect(result.email).toBe('test@example.com');
+    expect(result.bio).toBe('Hello');
+    expect(result.phone).toBe('+44 1234 567890');
+    expect(result.time_zone).toBe('Europe/London');
+    expect(result.location).toBe('Colchester');
+  });
+});
+
+describe('dhtToFormInput', () => {
+  it('splits a normal two-part name on the first space', () => {
+    const result = dhtToFormInput({ ...baseDHT, name: 'Maria Rodriguez' });
+    expect(result.given_name).toBe('Maria');
+    expect(result.family_name).toBe('Rodriguez');
+  });
+
+  it('preserves a compound family name (first-space split)', () => {
+    const result = dhtToFormInput({ ...baseDHT, name: 'Maria del Carmen Rodriguez' });
+    expect(result.given_name).toBe('Maria');
+    expect(result.family_name).toBe('del Carmen Rodriguez');
+  });
+
+  it('leaves family_name empty for a single-token name (mononym, NOT pre-filled with dot)', () => {
+    const result = dhtToFormInput({ ...baseDHT, name: 'Sting' });
+    expect(result.given_name).toBe('Sting');
+    expect(result.family_name).toBe('');
+  });
+
+  it('handles a stored sentinel-form name by restoring the dot to family_name', () => {
+    // A user who saved as a mononym has stored name "Sting ." - first-space
+    // split treats "." as the family_name, which is what we want for editing.
+    const result = dhtToFormInput({ ...baseDHT, name: 'Sting .' });
+    expect(result.given_name).toBe('Sting');
+    expect(result.family_name).toBe('.');
+  });
+
+  it('trims surrounding whitespace before splitting', () => {
+    const result = dhtToFormInput({ ...baseDHT, name: '  Maria Rodriguez  ' });
+    expect(result.given_name).toBe('Maria');
+    expect(result.family_name).toBe('Rodriguez');
+  });
+
+  it('preserves all other fields unchanged', () => {
+    const result = dhtToFormInput({
+      ...baseDHT,
+      name: 'Maria Rodriguez',
+      bio: 'Hello',
+      phone: '+44 1234 567890',
+      time_zone: 'Europe/London',
+      location: 'Colchester'
+    });
+    expect(result.nickname).toBe('tester');
+    expect(result.user_type).toBe('advocate');
+    expect(result.email).toBe('test@example.com');
+    expect(result.bio).toBe('Hello');
+    expect(result.phone).toBe('+44 1234 567890');
+    expect(result.time_zone).toBe('Europe/London');
+    expect(result.location).toBe('Colchester');
+  });
+});
+
+describe('round-trip: form -> DHT -> form', () => {
+  it('round-trips a normal two-part name', () => {
+    const original: UserFormInput = {
+      ...baseForm,
+      given_name: 'Maria',
+      family_name: 'Rodriguez'
+    };
+    const roundTripped = dhtToFormInput(formInputToDHT(original));
+    expect(roundTripped.given_name).toBe('Maria');
+    expect(roundTripped.family_name).toBe('Rodriguez');
+  });
+
+  it('round-trips a compound family name', () => {
+    const original: UserFormInput = {
+      ...baseForm,
+      given_name: 'Maria',
+      family_name: 'del Carmen Rodriguez'
+    };
+    const roundTripped = dhtToFormInput(formInputToDHT(original));
+    expect(roundTripped.given_name).toBe('Maria');
+    expect(roundTripped.family_name).toBe('del Carmen Rodriguez');
+  });
+
+  it('round-trips a mononymous user (family_name "." is preserved)', () => {
+    const original: UserFormInput = {
+      ...baseForm,
+      given_name: 'Sting',
+      family_name: '.'
+    };
+    const roundTripped = dhtToFormInput(formInputToDHT(original));
+    expect(roundTripped.given_name).toBe('Sting');
+    expect(roundTripped.family_name).toBe('.');
+  });
+});


### PR DESCRIPTION
## Issue

Closes #139

## Status

Open for review.

## Summary

Splits the user `name` field collection into separate "Given name" and "Family name" inputs in UserForm, while keeping the underlying DHT struct unchanged. The two values are concatenated at submit time. Mononymous users enter `.` in the family field as an explicit declaration; this sentinel is stripped at display time so users see e.g. "Welcome Sting" not "Welcome Sting .".

## What this PR does

- Adds `UserFormInputSchema` and `formInputToDHT` / `dhtToFormInput` transformations alongside the existing `UserInDHTSchema`
- Adds a `formatUserName` display helper that strips the sentinel dot
- Adds a `<UserName>` Svelte component for standalone name display
- Replaces the single Name input in UserForm with two side-by-side inputs
- Shows a one-time migration banner to existing users on first edit, asking them to confirm the split values (acknowledgment persists via localStorage keyed by `original_action_hash`)
- Wraps all display sites for `user.name` with `formatUserName(...)` or the `<UserName>` component as appropriate (16 sites across components, routes, stores, and one composable)
- Formats names at the hREA agent mapping boundary so consumer systems see clean labels (the action hash in `note` remains the canonical identity reference)
- Adds 26 unit tests for the transformations and display formatter

## What this PR does *not* do

- **Does not change the DHT struct.** `UserInDHT.name` is still a single `String`. No DNA bump, no migration, no breaking change to the data layer.
- **Does not introduce uniqueness validation.** Out of scope.
- **Does not change the nickname field.** Nickname remains required (`S.String` with `minLength(1)`), coherent with the Rust integrity zome.
- **Does not refactor form validation.** UserForm still uses HTML5 attributes (`required`, `pattern`) for its 9 fields, consistent with the pre-existing form. Migrating form validation to Effect Schema across UserForm / OrgForm / RequestForm / OfferForm is a separate architectural change worth its own focused PR.
- **Does not address pre-existing lint debt.** `bun run check` reports ~174 pre-existing eslint errors across the codebase (none in files this PR touched). Worth a follow-up issue.

## Out-of-scope work moved to follow-up

Two improvements that arose during smoke-testing have been extracted from this PR for separate review:

- **Nickname-optional + cross-app handle help text** — surfaced by Anita's demo feedback. Will land as a follow-up PR once this merges, paired with the corresponding Rust struct change to `Option<String>` (a DNA bump).
- **Popover styling polish for name-field help text** — wrapped help text in a Skeleton popover triggered by an ⓘ icon, fixed translucent-yellow popover background. Depends on the nickname-optional commit and will land in the same follow-up.

## Migration UX for existing users

On opening their profile to edit, existing users see a soft banner explaining the split, with their name pre-filled via first-space split. Once they acknowledge via the confirmation checkbox and save, the banner doesn't return for that user on that device (localStorage flag keyed by `original_action_hash`). Mononymous legacy users (single-token names with no sentinel dot, e.g. "Sacha") see an empty family field and must add a value or `.` before saving — the banner explains why.

## Testing

- 26/26 unit tests passing (`bunx vitest run tests/unit/utils/`)
- `svelte-check` clean (`bunx svelte-check --tsconfig ./tsconfig.json`, 0 errors 0 warnings)
- Manual smoke-test on aarch64-darwin: complete. Tested via `bun start` after the Nix dev shell fix from PR #153 was merged. All display sites verified, mononym round-trip works, migration banner one-time persistence verified.
- Mocks/fixtures audit: existing test data uses two-word names that round-trip cleanly through `dhtToFormInput`; no changes needed

## Target

`dev` branch