### PR TITLE
fix(nix): macOS compatibility for dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,13 +29,14 @@
           pkg-config
         ]) ++ [
           inputs'.holonix-playground.packages.hc-playground
+          inputs'.holonix.packages.bootstrap-srv
         ];
 
         shellHook = ''
           export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '
           # Required by bindgen (datachannel-sys) when building Sweettest tests natively
           export LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib"
-          export BINDGEN_EXTRA_CLANG_ARGS="-isystem ${pkgs.llvmPackages.libclang.lib}/lib/clang/$(ls ${pkgs.llvmPackages.libclang.lib}/lib/clang/)/include -isystem ${pkgs.glibc.dev}/include"
+          export BINDGEN_EXTRA_CLANG_ARGS="-isystem ${pkgs.llvmPackages.libclang.lib}/lib/clang/$(ls ${pkgs.llvmPackages.libclang.lib}/lib/clang/)/include${pkgs.lib.optionalString pkgs.stdenv.isLinux " -isystem ${pkgs.glibc.dev}/include"}"
         '';
       };
     };


### PR DESCRIPTION
## Summary

Fixes two Mac-specific issues that prevented entering the Holochain dev shell on `aarch64-darwin` (Apple Silicon). Both surfaced together when I attempted to set up a local R&O dev environment on macOS, and both needed to be fixed for `bun start` to launch the full local stack.

## The two issues

### 1. shellHook unconditional glibc reference

The `shellHook` set `BINDGEN_EXTRA_CLANG_ARGS` using a literal reference to the glibc dev output, but glibc is Linux-only — Darwin uses its own libc via the SDK. This caused the dev shell to fail to evaluate on macOS with:
error: Package 'glibc-nolibgcc' is not available on the requested hostPlatform:
hostPlatform.system = "aarch64-darwin"

**Fix:** Wrapped the glibc include path in `pkgs.lib.optionalString pkgs.stdenv.isLinux`, so the reference is only evaluated on Linux. On Darwin, clang locates system headers via the SDK automatically, so no replacement path is needed.

### 2. Missing kitsune2-bootstrap-srv binary

Holochain 0.6 extracted the bootstrap server from the main `holochain` binary into a standalone `kitsune2-bootstrap-srv` binary, spawned by `hc-spin` during local network setup. The binary wasn't on PATH because the `bootstrap-srv` package wasn't in the dev shell's packages list, causing:
Error: spawn kitsune2-bootstrap-srv ENOENT

**Fix:** Added the holonix `bootstrap-srv` package to the dev shell's `packages` list.

## Verified working on macOS

- `nix develop` enters cleanly
- `bun install` succeeds
- `bun run build:happ` compiles and packs the hApp
- `bun start` launches both agents, `kitsune2-bootstrap-srv` spawns correctly, two Electron windows open with the R&O UI
- End-to-end DHT communication between the two agents works as expected

PR #152 (contextual Alt+A navigation) was successfully smoke-tested on macOS as a direct result of this fix — and that smoke test caught a real cross-platform keyboard handler bug that would otherwise have shipped.

## Notes

- I'm the first Mac contributor exercising this path, which is why this regression went unnoticed.
- The fix is minimal and additive: Linux behaviour is completely unchanged. Only the Darwin path differs.
- Future Mac contributors should now be unblocked.