### PR TITLE
fix(#142): rename "My Activity" nav section to "Profile"

### DIFF
--- a/ui/src/lib/components/shared/NavBar.svelte
+++ b/ui/src/lib/components/shared/NavBar.svelte
@@ -57,7 +57,7 @@
   }
 
   // Navigation menu configurations
-  function myActivityItems() {
+  function profileItems() {
     const user = currentUser; // dereference the signal
     return [
       {
@@ -174,7 +174,7 @@
 
     <!-- Secondary Navigation -->
     <div class="flex items-center gap-4 text-white">
-      <NavDropdown title="My Activity" items={myActivityItems()} />
+      <NavDropdown title="Profile" items={profileItems()} />
 
       <NavDropdown title="Community" items={communityItems} />
 

--- a/ui/src/lib/components/shared/drawers/MenuDrawer.svelte
+++ b/ui/src/lib/components/shared/drawers/MenuDrawer.svelte
@@ -58,9 +58,9 @@
       </a>
     </div>
 
-    <!-- My Activity -->
+    <!-- Profile -->
     <div class="space-y-3">
-      <h3 class="text-sm font-semibold uppercase tracking-wide text-secondary-300">My Activity</h3>
+      <h3 class="text-sm font-semibold uppercase tracking-wide text-secondary-300">Profile</h3>
       <div class="space-y-2">
         {#if currentUser}
           <a


### PR DESCRIPTION
## What this changes

Resolves the profile discoverability issue Anita reported in #142.

The nav section that wraps "My Profile / My Requests / My Offers / My Listings" was labelled **"My Activity"** — which led users to think their profile lived somewhere else. Renamed the section to **"Profile"** in both the desktop `NavBar` and the mobile `MenuDrawer`, so the section heading reads as a category rather than a separate destination.

Before:                       After:
My Activity ▾                 Profile ▾
├ My Profile                  ├ My Profile
├ My Requests                 ├ My Requests
├ My Offers                   ├ My Offers
└ My Listings                 └ My Listings

## On the "Edit button" half of the issue

Anita also asked about an Edit button. The Edit Profile button **already exists** on `UserProfile.svelte` (line 242, gated by `{#if isCurrentUser}`) and renders correctly when visiting `/user`. The discoverability fix above resolves the underlying problem — once users find their profile, the Edit affordance is already clear. No changes needed there.

## Files changed

- `ui/src/lib/components/shared/NavBar.svelte` — dropdown title + internal helper function `myActivityItems()` → `profileItems()` for consistency
- `ui/src/lib/components/shared/drawers/MenuDrawer.svelte` — section heading + matching code comment

## Verification

- ✅ `bunx svelte-check` clean on both files
- ✅ `grep -rn "myActivity\|My Activity" ui/src` returns nothing
- ✅ Visual smoke test in full Nix dev env: desktop nav, dropdown contents, mobile drawer, Edit Profile button on `/user` all render correctly across both agents

## Note on the cherry-picked commit

This branch includes a cherry-pick of `f16b4227` from #153 (the Mac dev-shell Nix fix), needed for me to run `bun start` for visual verification. When #153 lands first, this picks up as a no-op duplicate at merge time. If #142 lands first, the commit ships with it; either way, no manual cleanup needed.

Closes #142