### PR TITLE
feat(#156): add MarkdownField wrapper with Preview mode

### DIFF
--- a/ui/src/lib/components/shared/MarkdownField.svelte
+++ b/ui/src/lib/components/shared/MarkdownField.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import MarkdownToolbar from './MarkdownToolbar.svelte';
+  import MarkdownRenderer from './MarkdownRenderer.svelte';
+
+  type Props = {
+    value?: string;
+    name?: string;
+    label?: string;
+    placeholder?: string;
+    rows?: number;
+    maxLength?: number;
+    required?: boolean;
+    showCharacterCount?: boolean;
+    height?: string;
+    onchange?: (value: string) => void;
+  };
+
+  let {
+    value = $bindable(''),
+    name,
+    label,
+    placeholder = 'Markdown supported',
+    rows = 4,
+    maxLength = 1000,
+    required = false,
+    showCharacterCount = true,
+    height = '',
+    onchange
+  }: Props = $props();
+
+  let textarea: HTMLTextAreaElement | undefined = $state(undefined);
+  let mode: 'edit' | 'preview' = $state('edit');
+
+  function handleToolbarChange(newValue: string) {
+    value = newValue;
+    onchange?.(newValue);
+  }
+
+  function handleTextareaInput(event: Event) {
+    const target = event.target as HTMLTextAreaElement;
+    value = target.value;
+    onchange?.(target.value);
+  }
+</script>
+
+<label class="label">
+  {#if label}
+    <span>
+      {label}{required ? '*' : ''} :
+      {#if showCharacterCount}
+        <span class="text-sm">({value.length}/{maxLength} characters)</span>
+      {/if}
+    </span>
+  {/if}
+
+  <div class="mb-1 flex justify-end gap-1">
+    <button
+      type="button"
+      class="btn btn-sm {mode === 'edit' ? 'variant-filled-primary' : 'variant-ghost-surface'}"
+      onclick={() => (mode = 'edit')}
+    >
+      Edit
+    </button>
+    <button
+      type="button"
+      class="btn btn-sm {mode === 'preview' ? 'variant-filled-primary' : 'variant-ghost-surface'}"
+      onclick={() => (mode = 'preview')}
+    >
+      Preview
+    </button>
+  </div>
+
+  <div class:hidden={mode !== 'edit'}>
+    <MarkdownToolbar {textarea} {value} onchange={handleToolbarChange} />
+    <textarea
+      class="textarea rounded-t-none {height}"
+      {name}
+      {rows}
+      maxlength={maxLength}
+      {placeholder}
+      {required}
+      bind:this={textarea}
+      bind:value
+      oninput={handleTextareaInput}
+    ></textarea>
+  </div>
+
+  {#if mode === 'preview'}
+    <div class="card variant-soft overflow-y-auto p-4 {height}">
+      {#if value.trim()}
+        <MarkdownRenderer content={value} />
+      {:else}
+        <p class="italic text-surface-400">
+          Nothing to preview yet — switch to Edit mode and type some markdown.
+        </p>
+      {/if}
+    </div>
+  {/if}
+</label>

--- a/ui/src/lib/components/shared/MarkdownField.svelte
+++ b/ui/src/lib/components/shared/MarkdownField.svelte
@@ -6,6 +6,7 @@
     value?: string;
     name?: string;
     label?: string;
+    labelClass?: string;
     placeholder?: string;
     rows?: number;
     maxLength?: number;
@@ -19,6 +20,7 @@
     value = $bindable(''),
     name,
     label,
+    labelClass = '',
     placeholder = 'Markdown supported',
     rows = 4,
     maxLength = 1000,
@@ -36,14 +38,14 @@
     onchange?.(newValue);
   }
 
-  function handleTextareaInput(event: Event) {
-    const target = event.target as HTMLTextAreaElement;
-    value = target.value;
-    onchange?.(target.value);
+  function handleTextareaInput() {
+    // bind:value already syncs the textarea value into `value`;
+    // this handler just fires the optional onchange callback.
+    onchange?.(value);
   }
 </script>
 
-<label class="label">
+<label class="label {labelClass}">
   {#if label}
     <span>
       {label}{required ? '*' : ''} :
@@ -57,6 +59,7 @@
     <button
       type="button"
       class="btn btn-sm {mode === 'edit' ? 'variant-filled-primary' : 'variant-ghost-surface'}"
+      aria-pressed={mode === 'edit'}
       onclick={() => (mode = 'edit')}
     >
       Edit
@@ -64,6 +67,7 @@
     <button
       type="button"
       class="btn btn-sm {mode === 'preview' ? 'variant-filled-primary' : 'variant-ghost-surface'}"
+      aria-pressed={mode === 'preview'}
       onclick={() => (mode = 'preview')}
     >
       Preview

--- a/ui/src/lib/components/users/UserForm.svelte
+++ b/ui/src/lib/components/users/UserForm.svelte
@@ -9,7 +9,7 @@
   import { shouldShowMockButtons } from '$lib/services/devFeatures.service';
   import { goto } from '$app/navigation';
   import weaveStore from '$lib/stores/weave.store.svelte';
-  import MarkdownToolbar from '$lib/components/shared/MarkdownToolbar.svelte';
+  import MarkdownField from '$lib/components/shared/MarkdownField.svelte';
 
   type Props = {
     mode: 'create' | 'edit';
@@ -37,7 +37,6 @@
   let isLoading = $state(false);
   let error = $state<string | null>(null);
   let bio = $state(user?.bio || '');
-  let bioTextarea: HTMLTextAreaElement | undefined = $state(undefined);
 
   const welcomeAndNextStepsMessage = (name: string) => `
   <img src="/hAppeningsCIClogo.png" alt="hAppenings Community Logo" class="w-28" />
@@ -204,18 +203,13 @@
     />
   </label>
 
-  <label class="label text-lg">
-    Bio : <span class="text-sm">({bio.length}/1000 characters)</span>
-    <MarkdownToolbar textarea={bioTextarea} value={bio} onchange={(v) => (bio = v)} />
-    <textarea
-      class="textarea h-52 rounded-t-none"
-      name="bio"
-      bind:this={bioTextarea}
-      bind:value={bio}
-      maxlength="1000"
-      placeholder="Tell us about yourself... (Markdown supported)"
-    ></textarea>
-  </label>
+  <MarkdownField
+    bind:value={bio}
+    name="bio"
+    label="Bio"
+    height="h-52"
+    placeholder="Tell us about yourself... (Markdown supported)"
+  />
 
   <div class="space-y-2">
     <label class="label space-y-2">

--- a/ui/src/lib/components/users/UserForm.svelte
+++ b/ui/src/lib/components/users/UserForm.svelte
@@ -207,6 +207,7 @@
     bind:value={bio}
     name="bio"
     label="Bio"
+    labelClass="text-lg"
     height="h-52"
     placeholder="Tell us about yourself... (Markdown supported)"
   />


### PR DESCRIPTION
Implements #156. Follow-up work tracked in #164 (preview height fallback) — must land before the rollout to other forms.

## What this changes

Adds an Edit/Preview toggle to markdown editing, addressing Steve Melville's report (originally under #140, now tracked as #156) that users had to save and reload to verify their markdown rendered correctly.

## How it's implemented

Introduces a new shared component, `MarkdownField.svelte`, that wraps the existing `MarkdownToolbar` + `<textarea>` + character-counter pattern that currently appears in:

- `UserForm.svelte` (bio)
- `RequestForm.svelte` (description)
- `OfferForm.svelte` (description)
- `OrganizationForm.svelte` (vision/mission)
- `ServiceTypeForm.svelte`, `ServiceTypeSuggestionForm.svelte`, `MediumOfExchangeSuggestionForm.svelte` (use the textarea pattern; markdown toolbar variable)

The wrapper adds Edit/Preview mode buttons and renders the value via the existing `MarkdownRenderer` component in preview mode. The textarea stays in the DOM (visually hidden via `class:hidden`) when in preview mode, so form submission continues to receive the value through the existing FormData pattern — no submit-handler changes needed.

## Scope of this PR

Only `UserForm.svelte` is migrated as a reference implementation. The other forms could be migrated in a follow-up PR — splitting that out keeps this review focused on the component's API shape rather than the rollout mechanics.

## Component API

Designed to match `$bindable` precedent from `TimeZoneSelect.svelte`:

```svelte
<MarkdownField
  bind:value={bio}
  name="bio"
  label="Bio"
  height="h-52"
  placeholder="Tell us about yourself... (Markdown supported)"
/>
```

Props:
- `value` (bindable, `$bindable('')`)
- `name`, `label`, `placeholder`, `required` — passed through to textarea, preserves FormData semantics
- `rows`, `height` — sizing (use `height` for Tailwind class like `h-52`, `rows` for line count)
- `maxLength` (default 1000) — matches the existing limit across forms
- `showCharacterCount` (default true)
- `onchange?` — optional callback alongside `bind:value`

## Known minor quirk

If a caller passes `rows` but not `height`, the preview pane has no height and renders empty. `UserForm` uses `height` so this isn't hit currently. Worth addressing when rolling out to forms that pass `rows` — likely by computing a fallback height from `rows` for the preview card.

## Verification

- ✅ `bunx svelte-check` clean on both files
- ✅ Visual smoke test in full Nix dev env (2 agents): Edit mode unchanged from prior behaviour, Preview toggle works, markdown renders correctly (`**bold**`, `*italic*`, `## heading`, `- list`), form save in Preview mode preserves bio data correctly

## Open question for review

The wrapper API includes both `bind:value` and an optional `onchange` callback. This matches `TimeZoneSelect.svelte`'s pattern but differs from `MarkdownToolbar.svelte` (callback-only). Happy to align to whichever convention you'd prefer — left as the more flexible `$bindable` pattern for now.

Impl #156. Follow-up work tracked in #164 (preview height fallback) — must land before the rollout to other forms.