### PR TITLE
fix(#157): replace TimeZoneSelect with proper combobox

### DIFF
--- a/ui/src/lib/components/shared/TimeZoneSelect.svelte
+++ b/ui/src/lib/components/shared/TimeZoneSelect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { DateTime } from 'luxon';
+  import { popup, type PopupSettings } from '@skeletonlabs/skeleton';
 
   type Props = {
     value?: string;
@@ -19,65 +20,224 @@
     onchange
   }: Props = $props();
 
-  // State
-  let timezones = Intl.supportedValuesOf('timeZone');
-  let filteredTimezones: string[] = $state([]);
+  // Stable popup target derived from id (or a fallback). Each instance gets a
+  // unique target so multiple TimeZoneSelects on one page don't collide.
+  const popupTarget = `tz-popup-${id ?? Math.random().toString(36).slice(2, 10)}`;
+
+  const popupSettings: PopupSettings = {
+    event: 'focus-click',
+    target: popupTarget,
+    placement: 'bottom-start',
+    closeQuery: ''
+  };
+
+  // All IANA timezones, sorted once.
+  const timezones = Intl.supportedValuesOf('timeZone').slice().sort();
+
+  // Browser-detected timezone shown as a one-click suggestion. Never auto-committed.
+  const detectedTimezone: string | undefined = (() => {
+    try {
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return tz && timezones.includes(tz) ? tz : undefined;
+    } catch {
+      return undefined;
+    }
+  })();
+
+  // Local UI state
   let search = $state('');
-
-  $effect(() => {
-    if (!search) {
-      filteredTimezones = timezones;
-      // If no value is pre-selected, default to the first timezone
-      if (!value && filteredTimezones.length > 0) {
-        value = filteredTimezones[0];
-        onchange?.(value);
-      }
-    }
-  });
-
-  $effect(() => {
-    timezones.sort();
-  });
-
-  function filterTimezones(event: Event) {
-    search = (event.target as HTMLInputElement).value.trim();
-    filteredTimezones = timezones.filter((tz) => tz.toLowerCase().includes(search.toLowerCase()));
-    // Auto-select the first timezone from the filtered list (if any)
-    if (filteredTimezones.length > 0) {
-      value = filteredTimezones[0];
-      onchange?.(value);
-    }
-  }
+  let isOpen = $state(false);
+  let highlightedIndex = $state(-1);
+  let inputEl: HTMLInputElement | undefined = $state();
+  let listEl: HTMLUListElement | undefined = $state();
 
   function getTimezoneDisplay(tz: string): string {
     try {
-      const now = DateTime.now().setZone(tz);
-      const offset = now.toFormat('ZZ');
+      const offset = DateTime.now().setZone(tz).toFormat('ZZ');
       return `${tz} (UTC${offset})`;
-    } catch (e) {
+    } catch {
       return tz;
     }
   }
 
-  function handleSelectChange(event: Event) {
-    const target = event.target as HTMLSelectElement;
-    const newValue = target.value || undefined;
-    onchange?.(newValue);
+  // Prioritised substring filter:
+  //   1. Matches at start of string (or after a '/') rank above mid-string matches.
+  //   2. Within each group, alphabetical order.
+  function filterAndRank(query: string): string[] {
+    const q = query.trim().toLowerCase();
+    if (!q) return timezones;
+    const starts: string[] = [];
+    const mids: string[] = [];
+    for (const tz of timezones) {
+      const lower = tz.toLowerCase();
+      if (lower.startsWith(q) || lower.includes('/' + q)) {
+        starts.push(tz);
+      } else if (lower.includes(q)) {
+        mids.push(tz);
+      }
+    }
+    return [...starts, ...mids];
   }
+
+  const filtered = $derived(filterAndRank(search));
+
+  // The visible text in the input.
+  //   - When the popup is closed: show the committed value's display string (or empty).
+  //   - When the popup is open: show whatever the user is typing.
+  const displayValue = $derived(isOpen ? search : value ? getTimezoneDisplay(value) : '');
+
+  function commit(tz: string | undefined) {
+    value = tz;
+    onchange?.(tz);
+    search = '';
+    isOpen = false;
+    highlightedIndex = -1;
+  }
+
+  function revert() {
+    search = '';
+    isOpen = false;
+    highlightedIndex = -1;
+  }
+
+  function handleInput(event: Event) {
+    search = (event.target as HTMLInputElement).value;
+    isOpen = true;
+    highlightedIndex = filtered.length > 0 ? 0 : -1;
+  }
+
+  function handleFocus() {
+    isOpen = true;
+    // Pre-fill the search with the committed display so the user can edit from it,
+    // or leave empty for a fresh filter. We leave empty: cleaner UX.
+    search = '';
+    highlightedIndex = -1;
+  }
+
+  function handleBlur(event: FocusEvent) {
+    // Defer so a click on a list item is processed before we close.
+    const next = event.relatedTarget as Node | null;
+    if (next && listEl?.contains(next)) return;
+    revert();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (!isOpen) {
+        isOpen = true;
+        highlightedIndex = 0;
+        return;
+      }
+      if (filtered.length === 0) return;
+      highlightedIndex = (highlightedIndex + 1) % filtered.length;
+      scrollHighlightedIntoView();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!isOpen || filtered.length === 0) return;
+      highlightedIndex = highlightedIndex <= 0 ? filtered.length - 1 : highlightedIndex - 1;
+      scrollHighlightedIntoView();
+    } else if (event.key === 'Enter') {
+      if (!isOpen) return;
+      event.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < filtered.length) {
+        commit(filtered[highlightedIndex]);
+        inputEl?.blur();
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      revert();
+      inputEl?.blur();
+    } else if (event.key === 'Tab') {
+      // Let tab proceed naturally; just close the popup.
+      revert();
+    }
+  }
+
+  function scrollHighlightedIntoView() {
+    queueMicrotask(() => {
+      const el = listEl?.querySelector(`[data-tz-index="${highlightedIndex}"]`);
+      (el as HTMLElement | null)?.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  function handleItemClick(tz: string) {
+    commit(tz);
+    inputEl?.blur();
+  }
+
+  // Stable id for the listbox so aria-controls / aria-activedescendant work.
+  const listboxId = `tz-listbox-${id ?? popupTarget}`;
+  const optionId = (i: number) => `${listboxId}-opt-${i}`;
 </script>
 
 <label class="label">
-  {label} <span class="text-error-500">{required ? '*' : ''}</span>
+  <span>{label} <span class="text-error-500">{required ? '*' : ''}</span></span>
+
   <input
+    bind:this={inputEl}
     type="text"
-    placeholder="Search timezones..."
-    class="input mb-2 w-full"
-    oninput={filterTimezones}
+    class="input"
+    role="combobox"
+    autocomplete="off"
+    aria-expanded={isOpen}
+    aria-controls={listboxId}
+    aria-activedescendant={highlightedIndex >= 0 ? optionId(highlightedIndex) : undefined}
+    aria-required={required}
+    placeholder="Select timezone..."
+    value={displayValue}
+    {id}
+    oninput={handleInput}
+    onfocus={handleFocus}
+    onblur={handleBlur}
+    onkeydown={handleKeydown}
+    use:popup={popupSettings}
   />
-  <select {name} {id} class="select w-full" {required} bind:value onchange={handleSelectChange}>
-    <option value="">Select timezone...</option>
-    {#each filteredTimezones as tz}
-      <option value={tz}>{getTimezoneDisplay(tz)}</option>
-    {/each}
-  </select>
+
+  <!-- Hidden input keeps FormData submissions working for UserForm. -->
+  <input type="hidden" {name} value={value ?? ''} {required} />
 </label>
+
+<div
+  class="card z-20 max-h-72 w-full max-w-md overflow-auto p-2 shadow-xl"
+  data-popup={popupTarget}
+>
+  <ul bind:this={listEl} role="listbox" id={listboxId} class="space-y-0.5">
+    {#if detectedTimezone && !search}
+      <li>
+        <button
+          type="button"
+          class="w-full rounded px-3 py-2 text-left text-sm variant-soft-primary hover:variant-filled-primary"
+          onclick={() => handleItemClick(detectedTimezone)}
+        >
+          <span class="block text-xs opacity-75">Detected from your browser</span>
+          <span class="block font-medium">{getTimezoneDisplay(detectedTimezone)}</span>
+        </button>
+      </li>
+      <li class="my-1 border-t border-surface-500/30"></li>
+    {/if}
+
+    {#if filtered.length === 0}
+      <li class="px-3 py-2 text-sm opacity-60">No timezones match "{search}"</li>
+    {:else}
+      {#each filtered as tz, i (tz)}
+        <li>
+          <button
+            type="button"
+            id={optionId(i)}
+            role="option"
+            aria-selected={i === highlightedIndex}
+            data-tz-index={i}
+            class="w-full rounded px-3 py-2 text-left text-sm hover:variant-soft-primary
+                   {i === highlightedIndex ? 'variant-soft-primary' : ''}
+                   {tz === value ? 'font-semibold' : ''}"
+            onmousedown={(e) => e.preventDefault()}
+            onclick={() => handleItemClick(tz)}
+          >
+            {getTimezoneDisplay(tz)}
+          </button>
+        </li>
+      {/each}
+    {/if}
+  </ul>
+</div>


### PR DESCRIPTION
Fixes #157.

The previous TimeZoneSelect combined a search input with a native `<select>`, which is structurally incoherent on the web — filtering while the OS-native dropdown is closed gives no live feedback. The component also silently overwrote the bound value on every keystroke (auto-selecting the first filtered match) and on mount (defaulting to the first timezone alphabetically). Steve Melville's alpha test reported this as 'the field doesn't commit the chosen timezone.'

### Approach

Replaced with a proper combobox using the popup infrastructure already wired in `+layout.svelte` (`@floating-ui/dom` + `storePopup`, used by NavBar's NetworkStatusPopup). No new dependencies.

### Changes
- Single visible input shows the committed timezone display string
- Popup beneath shows filtered list with prioritised substring match (start-of-segment matches rank above mid-string)
- Full keyboard navigation: arrows, Enter, Escape, Tab
- ARIA combobox role with `aria-expanded`, `aria-controls`, `aria-activedescendant`
- Browser-detected timezone shown as a one-click suggestion at the top of the popup, never silently committed (preserves user agency for VPN / wrong-clock cases)
- Hidden input preserves FormData submission path for UserForm
- `bind:value` and `onchange` callbacks unchanged, so OfferForm and RequestForm continue to work without changes

### Testing
- `bunx svelte-check` on the touched file: 0 errors, 0 warnings
- Manual smoke test in UserForm, OfferForm, RequestForm: empty-state, click-to-select detected suggestion, type-to-filter with prioritised ranking, keyboard nav, click outside reverts, submit persists to DHT

### Note
Branch also includes cherry-pick of `f16b4227` (Nix dev shell fix from #153) so this PR can build on aarch64-darwin until #153 merges. That cherry-pick resolves as a no-op duplicate once #153 lands.