### PR TITLE
fix(#155): preserve scroll position after markdown toolbar action

### DIFF
--- a/ui/src/lib/components/shared/MarkdownToolbar.svelte
+++ b/ui/src/lib/components/shared/MarkdownToolbar.svelte
@@ -12,6 +12,7 @@
 
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
+    const scrollTop = textarea.scrollTop;
     const selected = value.substring(start, end);
 
     const newValue = value.substring(0, start) + before + selected + after + value.substring(end);
@@ -25,6 +26,7 @@
         const cursorPos = start + before.length;
         textarea.setSelectionRange(cursorPos, cursorPos);
       }
+      textarea.scrollTop = scrollTop;
     });
   }
 
@@ -32,6 +34,7 @@
     if (!textarea) return;
 
     const start = textarea.selectionStart;
+    const scrollTop = textarea.scrollTop;
     const lineStart = value.lastIndexOf('\n', start - 1) + 1;
 
     const newValue = value.substring(0, lineStart) + prefix + value.substring(lineStart);
@@ -40,6 +43,7 @@
     requestAnimationFrame(() => {
       textarea.focus();
       textarea.setSelectionRange(start + prefix.length, start + prefix.length);
+      textarea.scrollTop = scrollTop;
     });
   }
 </script>


### PR DESCRIPTION
Closes #155.

## Problem
In the markdown editor (for example the bio field in the profile form), clicking a toolbar wrap action — Bold, Italic, and so on — scrolled the textarea back to the top and lost the editing position. Reported by a tester editing a long bio.

## Cause
The wrap handlers in `MarkdownToolbar` (`insertMarkdown`, `insertLinePrefix`) restored the cursor via `setSelectionRange` inside a `requestAnimationFrame`, but never saved or restored `scrollTop`. Reassigning the textarea value through the `onchange` callback resets scroll to the top, and nothing put it back.

## Fix
Capture `scrollTop` before the value change and restore it as the last step of the `requestAnimationFrame` in both handlers — four lines, alongside the existing cursor-restore logic. The change is in the shared `MarkdownToolbar`, so every editor built on `MarkdownField` benefits, not just the profile form.

## Testing
Type-checked clean (`svelte-check`, 0 errors). No unit test added: the UI test setup mocks out Svelte components, and jsdom has no layout engine, so `scrollTop` is always 0 there, which means a unit test cannot exercise this behaviour. The wrap handlers are component-internal, so there is nothing pure to import and test in isolation. A Playwright e2e covering scroll-after-wrap would be the right home for regression coverage and could follow as a separate change. Verified here by inspection against the existing cursor-restore pattern, plus the type-check.
