### PR TITLE
chore: bump hREA to happ-0.4.0-beta (VF 1.0 + Holochain 0.6.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "package": "bun run build:happ && VITE_MOCK_BUTTONS_ENABLED=false VITE_PEERS_DISPLAY_ENABLED=false bun --filter ui package && hc web-app pack workdir --recursive",
     "build:happ": "bun run build:zomes && hc app pack workdir --recursive",
     "build:zomes": "RUSTFLAGS='--cfg getrandom_backend=\"custom\"' cargo build --release --target wasm32-unknown-unknown",
-    "download-hrea": "[ ! -f \"workdir/hrea.dna\" ] && curl -L --output workdir/hrea.dna https://github.com/h-REA/hREA/releases/download/happ-0.3.4-beta/hrea.dna; exit 0",
+    "download-hrea": "[ ! -f \"workdir/hrea.dna\" ] && curl -L --output workdir/hrea.dna https://github.com/h-REA/hREA/releases/download/happ-0.4.0-beta/hrea.dna; exit 0",
     "clean:hrea": "rimraf workdir/hrea.dna",
     "check": "cd ui && bun run check && bun run lint",
     "build:ui": "cd ui && bun run build"


### PR DESCRIPTION
## What

Bumps the hREA release-asset pin from `happ-0.3.4-beta` to **`happ-0.4.0-beta`** — the new pre-release cut from hREA's `feat/vf-proposal-purpose` integration branch ([h-REA/hREA#408](https://github.com/h-REA/hREA/pull/408), [release](https://github.com/h-REA/hREA/releases/tag/happ-0.4.0-beta)).

Single-line change to `package.json`'s `download-hrea` script.

## Why

hREA 0.4.0-beta brings the full ValueFlows 1.0 compliance surface and aligns on Holochain 0.6.1 (which R&O already migrated to independently in #171). This lets us test the VF 1.0 hREA layer (proposals, intents, agents, resource specs) inside R&O and unblocks future exchange-process UI work.

## Compatibility

Binary-compatible with R&O's current usage. Verified:
- R&O does **not** consume `ProductBatch` or `Commitment.inScopeOf` — the only two surfaces removed in VF 1.0 (grep: zero matches in `ui/src`).
- R&O's `offers`/`requests` are its own domain concept (its own stores/components), not hREA's new VF 1.0 `Proposal.purpose` queries — so the new capability is additive and unconsumed, not breaking.

## Verification

| check | result |
|-------|--------|
| `bun install` (downloads new `hrea.dna`) | ✅ 826 packages, dna = 1684323 bytes (byte-identical to release asset) |
| `bun run build:happ` | ✅ both DNAs packed (R&O + hrea 0.4.0-beta) |
| unit tests (`nix develop bun test:unit`) | ✅ **443 passed** / 25 files (incl. `hrea.service.test.ts`, `hrea.store.test.ts`) |
| e2e suite (`bun test:e2e`, live sandbox conductor) | ✅ **46 passed** / 3.5m (incl. `08-hrea.spec.ts` — hREA cell mounts against the new DNA) |

The basic hREA implementation is complete and solid: `hrea.service.ts` exposes full CRUD for Agents (Person/Organization), ResourceSpecification, Proposal, and Intent over Apollo + SchemaLink + the vf-graphql-holochain adapter targeting the `hrea` role; the e2e smoke test confirms the cell installs and the admin test interface mounts without error.

## Related

- hREA release: https://github.com/h-REA/hREA/releases/tag/happ-0.4.0-beta
- hREA PR: https://github.com/h-REA/hREA/pull/408
- hREA review findings applied on the tag: dead-code removal + referential-validation symmetry in `rea_economic_event.rs`

## Notes

- hREA's `release.yml` CI workflow is stale (broken build script); the 0.4.0-beta assets were built and uploaded locally, same as prior 0.3.x releases. Fixing hREA's release CI is tracked as a follow-up there.
- No code changes beyond the pin bump.